### PR TITLE
Release 2.21

### DIFF
--- a/Dokumentation/index.html
+++ b/Dokumentation/index.html
@@ -659,7 +659,7 @@ table.CodeRay td.code>pre{padding:0}
 <div class="sect2">
 <h3 id="_aktuelle_version">Aktuelle Version</h3>
 <div class="paragraph">
-<p><em>Version</em> : 2.20</p>
+<p><em>Version</em> : 2.21</p>
 </div>
 </div>
 <div class="sect2">
@@ -3155,6 +3155,15 @@ table.CodeRay td.code>pre{padding:0}
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>&lt; <a href="#_risikoabsicherung">RisikoAbsicherung</a> &gt; array</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>externeAngebotsNummer</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
 </div></div></td>
 </tr>
 <tr>
@@ -10724,7 +10733,7 @@ table.CodeRay td.code>pre{padding:0}
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-03-26 13:13:12 +0100
+Last updated 2020-04-08 09:43:21 +0200
 </div>
 </div>
 </body>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Anträge API
 
-##### Aktuelle Version: 2.19
+##### Aktuelle Version: 2.21
 
 [Aktuelles RELEASE](https://github.com/hypoport/antraege-auslesen-api/releases/)
 

--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Securitykontext des Produktanbieters eingenommen.",
-    "version": "2.20",
+    "version": "2.21",
     "title": "Anträge auslesen API",
     "contact": {
       "name": "Europace AG",
@@ -944,6 +944,9 @@
           "items": {
             "$ref": "#/definitions/RisikoAbsicherung"
           }
+        },
+        "externeAngebotsNummer": {
+          "type": "string"
         },
         "gesamtPraemie": {
           "type": "number"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2,7 +2,7 @@
 swagger: "2.0"
 info:
   description: Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Securitykontext des Produktanbieters eingenommen.
-  version: "2.20"
+  version: "2.21"
   title: Anträge auslesen API
   contact:
     name: Europace AG
@@ -640,6 +640,8 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/RisikoAbsicherung'
+      externeAngebotsNummer:
+        type: string
       gesamtPraemie:
         type: number
       praemienZahlungsweise:


### PR DESCRIPTION
- Neues String-Feld `externeAngebotsNummer` in `Absicherung` als Identifikationsmerkmal für ein Versicherungsangebot