### PR TITLE
[BEV-43] Release 2.22: europaceGebuehrenSindSteuerpflichtig

### DIFF
--- a/Dokumentation/index.html
+++ b/Dokumentation/index.html
@@ -659,7 +659,7 @@ table.CodeRay td.code>pre{padding:0}
 <div class="sect2">
 <h3 id="_aktuelle_version">Aktuelle Version</h3>
 <div class="paragraph">
-<p><em>Version</em> : 2.21</p>
+<p><em>Version</em> : 2.22</p>
 </div>
 </div>
 <div class="sect2">
@@ -9369,6 +9369,16 @@ table.CodeRay td.code>pre{padding:0}
 </tr>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>europaceGebuehrenSindSteuerpflichtig</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>boolean</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>kundenbetreuerProvision</strong><br>
 <em>optional</em></p>
 </div></div></td>
@@ -10733,7 +10743,7 @@ table.CodeRay td.code>pre{padding:0}
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-04-08 09:43:21 +0200
+Last updated 2020-04-21 18:34:55 +0200
 </div>
 </div>
 </body>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Anträge API
 
-##### Aktuelle Version: 2.21
+##### Aktuelle Version: 2.22
 
 [Aktuelles RELEASE](https://github.com/hypoport/antraege-auslesen-api/releases/)
 

--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Securitykontext des Produktanbieters eingenommen.",
-    "version": "2.21",
+    "version": "2.22",
     "title": "Anträge auslesen API",
     "contact": {
       "name": "Europace AG",
@@ -3345,6 +3345,9 @@
         "europaceGebuehren": {
           "type": "number",
           "description": "Beinhaltet nur den selbst aufzubringenden Betrag"
+        },
+        "europaceGebuehrenSindSteuerpflichtig": {
+          "type": "boolean"
         },
         "kundenbetreuerProvision": {
           "type": "number"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2,7 +2,7 @@
 swagger: "2.0"
 info:
   description: Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Securitykontext des Produktanbieters eingenommen.
-  version: "2.21"
+  version: "2.22"
   title: Anträge auslesen API
   contact:
     name: Europace AG
@@ -2350,6 +2350,8 @@ definitions:
       europaceGebuehren:
         type: number
         description: Beinhaltet nur den selbst aufzubringenden Betrag
+      europaceGebuehrenSindSteuerpflichtig:
+        type: boolean
       kundenbetreuerProvision:
         type: number
       vertriebsProvisionGesamt:


### PR DESCRIPTION
* im Bankeigenvertrieb ist die Europace-Plattform-Gebühr
  steuerpflichtig für den Produktanbieter. Das wird durch ein
  boolesches Flag europaceGebuehrenSindSteuerpflichtig in der
  Provision kenntlich gemacht.

Closes [BEV-43]

[BEV-43]: https://europace.atlassian.net/browse/BEV-43