### PR TITLE
[BEV-217] Entwurf Anträge-API-Erweiterung

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1479,6 +1479,7 @@ definitions:
           - ANNUITAETEN_DARLEHEN
           - FORWARD_DARLEHEN
           - KFW_DARLEHEN
+          - REGIONAL_FOERDER_DARLEHEN
           - PRIVAT_DARLEHEN
           - ZWISCHEN_FINANZIERUNG
           - VARIABLES_DARLEHEN
@@ -1503,6 +1504,9 @@ definitions:
       kfwProgramm:
         type: string
         description: 'nur bei darlehensTyp==KFW_DARLEHEN. Mögliche Werte: PROGRAMM_124, PROGRAMM_141, PROGRAMM_151, PROGRAMM_152, PROGRAMM_153, PROGRAMM_155, PROGRAMM_159, PROGRAMM_167. Bei neu aufgelegten KfW-Programmen können auch weitere Werte zulässig werden.'
+      regionalFoerderbankProgramm:
+        type: string
+        description: 'nur bei darlehensType==REGIONAL_FOERDER_DARLEHEN. Mögliche Werte: L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, L_BANK_WOHNEN_MIT_ZUKUNFT. Bei neu aufgelegten Programmen bzw. Aufnahme weiterer regionaler Förderbanken in die Plattform können weitere Werte zulässig werden.'
       konditionWurdeManuellAngepasst:
         type: boolean
       konditionsAnpassungsBegruendung:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1506,7 +1506,7 @@ definitions:
         description: 'nur bei darlehensTyp==KFW_DARLEHEN. Mögliche Werte: PROGRAMM_124, PROGRAMM_141, PROGRAMM_151, PROGRAMM_152, PROGRAMM_153, PROGRAMM_155, PROGRAMM_159, PROGRAMM_167. Bei neu aufgelegten KfW-Programmen können auch weitere Werte zulässig werden.'
       regionalFoerderbankProgramm:
         type: string
-        description: 'nur bei darlehensType==REGIONAL_FOERDER_DARLEHEN. Mögliche Werte: L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, L_BANK_WOHNEN_MIT_ZUKUNFT. Bei neu aufgelegten Programmen bzw. Aufnahme weiterer regionaler Förderbanken in die Plattform können weitere Werte zulässig werden.'
+        description: 'nur bei darlehensTyp==REGIONAL_FOERDER_DARLEHEN. Mögliche Werte: L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, L_BANK_WOHNEN_MIT_ZUKUNFT. Bei neu aufgelegten Programmen bzw. Aufnahme weiterer regionaler Förderbanken in die Plattform können weitere Werte zulässig werden.'
       konditionWurdeManuellAngepasst:
         type: boolean
       konditionsAnpassungsBegruendung:


### PR DESCRIPTION
Achtung: dieser PR ist (noch) _nicht_ zur unmittelbaren Integration vorgesehen. Er zeigt nur anhand der Open-API-Spec der Anträge-API, wie wir uns die Erweiterung vorstellen. (die Open-API-Spec wird ja später dann aus dem Code des Anträge-Edge-Service generiert, das kann aber ggf. in diesem PR geschehen)

Die Erweiterung folgt dem Muster des BaufiSmart-Modells und der BaufiSmart-EFI-API, angepasst auf die Konventionen der Anträge-API:

* es wird keine neue Darlehens-Definition eingeführt, da die Anträge-API alle Arten von Darlehen in einer gemeinsamen Definition `Darlehen` abbildet
* es gibt einen neuen DarlehensTyp `REGIONAL_FOERDER_DARLEHEN`
* es gibt ein neues Darlehens-Attribut `regionalFoerderbankProgramm`, analog zu `kfwProgramm`
* analog zu den Kfw-Programmen werden auch die Regional-Förderbank-Programme _nicht_ als Aufzählung in der API spezifiziert, sondern nur als Kommentar, um gegenüber neuen Programmen flexibel zu bleiben
* die Regional-Förder-Darlehen und KfW-Darlehen werden insbesondere aus Kompatibilitätsgründen getrennt gehalten, obwohl sie strukturell weitgehend übereinstimmen (mit Ausnahme des `kfwEnergieEffizienzStandard` haben KfW- und Regional-Förderdarlehen alle Attribute gemeinsam)

Closes [BEV-217]

[BEV-217]: https://europace.atlassian.net/browse/BEV-217