### PR TITLE
[BEV-215] Release 2.23 mit Regional-Förder-Darlehen

### DIFF
--- a/Dokumentation/index.html
+++ b/Dokumentation/index.html
@@ -659,7 +659,7 @@ table.CodeRay td.code>pre{padding:0}
 <div class="sect2">
 <h3 id="_aktuelle_version">Aktuelle Version</h3>
 <div class="paragraph">
-<p><em>Version</em> : 2.22</p>
+<p><em>Version</em> : 2.23</p>
 </div>
 </div>
 <div class="sect2">
@@ -4488,7 +4488,9 @@ table.CodeRay td.code>pre{padding:0}
 <p><strong>einmalzahlung</strong><br>
 <em>optional</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>number</p>
 </div></div></td>
@@ -4669,7 +4671,9 @@ table.CodeRay td.code>pre{padding:0}
 <p><strong>einmalzahlung</strong><br>
 <em>optional</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>number</p>
 </div></div></td>
@@ -5463,7 +5467,9 @@ table.CodeRay td.code>pre{padding:0}
 <p><strong>einmalzahlung</strong><br>
 <em>optional</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>number</p>
 </div></div></td>
@@ -6166,7 +6172,7 @@ table.CodeRay td.code>pre{padding:0}
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p>enum (ANNUITAETEN_DARLEHEN, FORWARD_DARLEHEN, KFW_DARLEHEN, PRIVAT_DARLEHEN, ZWISCHEN_FINANZIERUNG, VARIABLES_DARLEHEN)</p>
+<p>enum (ANNUITAETEN_DARLEHEN, FORWARD_DARLEHEN, KFW_DARLEHEN, REGIONAL_FOERDER_DARLEHEN, PRIVAT_DARLEHEN, ZWISCHEN_FINANZIERUNG, VARIABLES_DARLEHEN)</p>
 </div></div></td>
 </tr>
 <tr>
@@ -6350,6 +6356,18 @@ table.CodeRay td.code>pre{padding:0}
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>number</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>regionalFoerderbankProgramm</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>nur bei darlehensTyp==REGIONAL_FOERDER_DARLEHEN. Mögliche Werte: L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, L_BANK_WOHNEN_MIT_ZUKUNFT. Bei neu aufgelegten Programmen bzw. Aufnahme weiterer regionaler Förderbanken in die Plattform können weitere Werte zulässig werden.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
 </div></div></td>
 </tr>
 <tr>
@@ -10743,7 +10761,7 @@ table.CodeRay td.code>pre{padding:0}
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-04-21 18:34:55 +0200
+Last updated 2020-06-09 17:23:10 +0200
 </div>
 </div>
 </body>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Anträge API
 
-##### Aktuelle Version: 2.22
+##### Aktuelle Version: 2.23
 
 [Aktuelles RELEASE](https://github.com/hypoport/antraege-auslesen-api/releases/)
 

--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Securitykontext des Produktanbieters eingenommen.",
-    "version": "2.22",
+    "version": "2.23",
     "title": "Anträge auslesen API",
     "contact": {
       "name": "Europace AG",
@@ -1491,7 +1491,8 @@
           "type": "number"
         },
         "einmalzahlung": {
-          "type": "number"
+          "type": "number",
+          "description": "Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen."
         },
         "id": {
           "type": "string"
@@ -1552,7 +1553,8 @@
           "type": "number"
         },
         "einmalzahlung": {
-          "type": "number"
+          "type": "number",
+          "description": "Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen."
         },
         "gesamtLaufzeitInJahren": {
           "type": "integer",
@@ -1843,7 +1845,8 @@
           "type": "number"
         },
         "einmalzahlung": {
-          "type": "number"
+          "type": "number",
+          "description": "Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen."
         },
         "id": {
           "type": "string"
@@ -2114,6 +2117,7 @@
             "ANNUITAETEN_DARLEHEN",
             "FORWARD_DARLEHEN",
             "KFW_DARLEHEN",
+            "REGIONAL_FOERDER_DARLEHEN",
             "PRIVAT_DARLEHEN",
             "ZWISCHEN_FINANZIERUNG",
             "VARIABLES_DARLEHEN"
@@ -2183,6 +2187,10 @@
         "rateMonatlichInDerTilgungsfreienAnlaufzeit": {
           "type": "number",
           "description": "nur bei darlehensTyp==KFW_DARLEHEN"
+        },
+        "regionalFoerderbankProgramm": {
+          "type": "string",
+          "description": "nur bei darlehensTyp==REGIONAL_FOERDER_DARLEHEN. Mögliche Werte: L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, L_BANK_WOHNEN_MIT_ZUKUNFT. Bei neu aufgelegten Programmen bzw. Aufnahme weiterer regionaler Förderbanken in die Plattform können weitere Werte zulässig werden."
         },
         "sollZins": {
           "type": "number",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2,7 +2,7 @@
 swagger: "2.0"
 info:
   description: Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Securitykontext des Produktanbieters eingenommen.
-  version: "2.22"
+  version: "2.23"
   title: Anträge auslesen API
   contact:
     name: Europace AG
@@ -1035,6 +1035,7 @@ definitions:
         type: number
       einmalzahlung:
         type: number
+        description: Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.
       id:
         type: string
       produktAnbieter:
@@ -1077,6 +1078,7 @@ definitions:
         type: number
       einmalzahlung:
         type: number
+        description: Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.
       gesamtLaufzeitInJahren:
         type: integer
         format: int32
@@ -1284,6 +1286,7 @@ definitions:
         type: number
       einmalzahlung:
         type: number
+        description: Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.
       id:
         type: string
       maximalAufzuloesenderBetrag:
@@ -1479,6 +1482,7 @@ definitions:
           - ANNUITAETEN_DARLEHEN
           - FORWARD_DARLEHEN
           - KFW_DARLEHEN
+          - REGIONAL_FOERDER_DARLEHEN
           - PRIVAT_DARLEHEN
           - ZWISCHEN_FINANZIERUNG
           - VARIABLES_DARLEHEN
@@ -1531,6 +1535,9 @@ definitions:
       rateMonatlichInDerTilgungsfreienAnlaufzeit:
         type: number
         description: nur bei darlehensTyp==KFW_DARLEHEN
+      regionalFoerderbankProgramm:
+        type: string
+        description: 'nur bei darlehensTyp==REGIONAL_FOERDER_DARLEHEN. Mögliche Werte: L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, L_BANK_WOHNEN_MIT_ZUKUNFT. Bei neu aufgelegten Programmen bzw. Aufnahme weiterer regionaler Förderbanken in die Plattform können weitere Werte zulässig werden.'
       sollZins:
         type: number
         example: 2.05


### PR DESCRIPTION
## Motivation

Die zur Abbildung der Darlehen der L-Bank und weiterer Förderbanken neu eingeführten Regional-Förder-Darlehen sollen auch an der Antrags-API ausgegeben werden.

Dieser PR korrespondiert mit dem Entwurf in #95 sowie der Erweiterung des Edge-Servers in https://github.com/hypoport/antraege-edge-server/pull/179

## Changes

* Darlehen unterstützt jetzt auch die Abbildung von regionalen Förder-Darlehen,
  dafür wird der neue `DarlehensTyp` `REGIONAL_FOERDER_DARLEHEN` eingeführt und
  ein neues Darlehens-Attribut `regionalFoerderbankProgramm` (aktuelle Änderung aus https://github.com/hypoport/antraege-edge-server/pull/179)
* Das Attribut `einmalzahlung` an `Bausparvertrag` und `BausparAngebot` ist nun als _"deprecated"_ markiert, und wird von der Anträge-API nicht mehr ausgeliefert (bislang nicht-publizierte Änderung aus https://github.com/hypoport/antraege-edge-server/pull/158)

Closes [BEV-215]

[BEV-215]: https://europace.atlassian.net/browse/BEV-215