### PR TITLE
Europace duzt jetzt seine Partner

### DIFF
--- a/Dokumentation/index.html
+++ b/Dokumentation/index.html
@@ -829,7 +829,7 @@ table.CodeRay td.code>pre{padding:0}
 <em>optional</em></p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p>Suche nach Ihrer antragsReferenz</p>
+<p>Suche nach deiner antragsReferenz</p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>string</p>
@@ -1520,7 +1520,7 @@ table.CodeRay td.code>pre{padding:0}
 <div class="sect4">
 <h5 id="_beschreibung_4">Beschreibung</h5>
 <div class="paragraph">
-<p>Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat. Nutzen sie den Endpunkt /{vorgang}/{antrag}/{teilAntrag}/angebot</p>
+<p>Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat. Nutze den Endpunkt /{vorgang}/{antrag}/{teilAntrag}/angebot</p>
 </div>
 </div>
 <div class="sect4">
@@ -3521,7 +3521,7 @@ table.CodeRay td.code>pre{padding:0}
 <em>optional</em></p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p>Nummer des Antrags in Ihrem System (ändernbar)</p>
+<p>Nummer des Antrags in deinem System (ändernbar)</p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>string</p>
@@ -10761,7 +10761,7 @@ table.CodeRay td.code>pre{padding:0}
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-06-09 17:23:10 +0200
+Last updated 2020-06-10 15:09:53 +0200
 </div>
 </div>
 </body>

--- a/swagger.json
+++ b/swagger.json
@@ -70,7 +70,7 @@
           {
             "name": "antragsReferenz",
             "in": "query",
-            "description": "Suche nach Ihrer antragsReferenz",
+            "description": "Suche nach deiner antragsReferenz",
             "required": false,
             "type": "string",
             "allowEmptyValue": false
@@ -335,7 +335,7 @@
           "Antraege"
         ],
         "summary": "Angebot des Antrags abrufen. ",
-        "description": "Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat.  Nutzen sie den Endpunkt /{vorgang}/{antrag}/{teilAntrag}/angebot",
+        "description": "Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat.  Nutze den Endpunkt /{vorgang}/{antrag}/{teilAntrag}/angebot",
         "operationId": "getAngebot_1",
         "produces": [
           "application/json;charset=UTF-8"
@@ -1097,7 +1097,7 @@
         },
         "antragsReferenz": {
           "type": "string",
-          "description": "Nummer des Antrags in Ihrem System (ändernbar)"
+          "description": "Nummer des Antrags in deinem System (ändernbar)"
         },
         "beratung": {
           "description": "Informationen zum Geschäftsabschluss",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -53,7 +53,7 @@ paths:
           x-example: 2016-03-11T10:57:45Z
         - name: antragsReferenz
           in: query
-          description: Suche nach Ihrer antragsReferenz
+          description: Suche nach deiner antragsReferenz
           required: false
           type: string
           allowEmptyValue: false
@@ -231,7 +231,7 @@ paths:
       tags:
         - Antraege
       summary: 'Angebot des Antrags abrufen. '
-      description: Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat.  Nutzen sie den Endpunkt /{vorgang}/{antrag}/{teilAntrag}/angebot
+      description: Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat.  Nutze den Endpunkt /{vorgang}/{antrag}/{teilAntrag}/angebot
       operationId: getAngebot_1
       produces:
         - application/json;charset=UTF-8
@@ -746,7 +746,7 @@ definitions:
         description: Nummer des Antrags auf der Europace Plattform
       antragsReferenz:
         type: string
-        description: Nummer des Antrags in Ihrem System (ändernbar)
+        description: Nummer des Antrags in deinem System (ändernbar)
       beratung:
         description: Informationen zum Geschäftsabschluss
         $ref: '#/definitions/Beratung'


### PR DESCRIPTION
### Motivation
Wir haben Ende des letzten Jahres die Entscheidung getroffen, die Ansprache der Plattformnutzer auf “du” umzustellen. Es drückt unsere Partnerschaft aus und ermöglicht uns durch die sprachliche Nähe offen und ehrlich über den Nutzen der Plattform für unsere Partner zu sprechen. 
Internes Jira Ticket: EN-262

### Änderungen
Beschreibungstexte von `Sie` auf `du` umgebaut.