### PR TITLE
Release 2.26

### DIFF
--- a/Dokumentation/index.html
+++ b/Dokumentation/index.html
@@ -577,7 +577,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="sect2">
 <h3 id="_aktuelle_version">Aktuelle Version</h3>
 <div class="paragraph">
-<p><em>Version</em> : 2.25</p>
+<p><em>Version</em> : 2.26</p>
 </div>
 </div>
 <div class="sect2">
@@ -4563,6 +4563,18 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </tr>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>gesamtLaufzeitInJahren</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>nur bei neuen extern berechneten Bausparverträgen</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>integer (int32)</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>id</strong><br>
 <em>optional</em></p>
 </div></div></td>
@@ -4659,6 +4671,18 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <td class="tableblock halign-left valign-middle"><div class="content"></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>string</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>vertragsPartner</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>nur bei neuen extern berechneten Bausparverträgen</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>&lt; <a href="#_antragstellerverknuepfung">AntragstellerVerknuepfung</a> &gt; array</p>
 </div></div></td>
 </tr>
 <tr>
@@ -4761,7 +4785,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p><strong>gesamtLaufzeitInJahren</strong><br>
 <em>optional</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>nur bei neuen extern berechneten Bausparverträgen</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>integer (int32)</p>
 </div></div></td>
@@ -6389,6 +6415,18 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>integer (int32)</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>kalkulatorischesLaufzeitEnde</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>bei allen Darlehenstypen außer darlehensTyp==ZWISCHEN_FINANZIERUNG</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string (date)</p>
 </div></div></td>
 </tr>
 <tr>
@@ -11010,7 +11048,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-08-21 10:54:35 +0200
+Last updated 2020-09-03 10:03:42 +0200
 </div>
 </div>
 </body>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Anträge API
 
-##### Aktuelle Version: 2.25
+##### Aktuelle Version: 2.26
 
 [Aktuelles RELEASE](https://github.com/hypoport/antraege-auslesen-api/releases/)
 

--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Securitykontext des Produktanbieters eingenommen.",
-    "version": "2.25",
+    "version": "2.26",
     "title": "Anträge auslesen API",
     "contact": {
       "name": "Europace AG",
@@ -1569,6 +1569,11 @@
           "type": "number",
           "description": "Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen."
         },
+        "gesamtLaufzeitInJahren": {
+          "type": "integer",
+          "format": "int32",
+          "description": "nur bei neuen extern berechneten Bausparverträgen"
+        },
         "id": {
           "type": "string"
         },
@@ -1603,6 +1608,13 @@
         },
         "vertragsNummer": {
           "type": "string"
+        },
+        "vertragsPartner": {
+          "type": "array",
+          "description": "nur bei neuen extern berechneten Bausparverträgen",
+          "items": {
+            "$ref": "#/definitions/AntragstellerVerknuepfung"
+          }
         },
         "verwaltungsgebuehrenJaehrlich": {
           "type": "number"
@@ -1641,7 +1653,8 @@
         },
         "gesamtLaufzeitInJahren": {
           "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "description": "nur bei neuen extern berechneten Bausparverträgen"
         },
         "id": {
           "type": "string"
@@ -2264,6 +2277,11 @@
           "type": "integer",
           "format": "int32",
           "description": "nur bei darlehensTyp==FORWARD_DARLEHEN"
+        },
+        "kalkulatorischesLaufzeitEnde": {
+          "type": "string",
+          "format": "date",
+          "description": "bei allen Darlehenstypen außer darlehensTyp==ZWISCHEN_FINANZIERUNG"
         },
         "kfwEnergieEffizienzStandard": {
           "type": "string",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2,7 +2,7 @@
 swagger: "2.0"
 info:
   description: Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Securitykontext des Produktanbieters eingenommen.
-  version: "2.25"
+  version: "2.26"
   title: Anträge auslesen API
   contact:
     name: Europace AG
@@ -1087,6 +1087,10 @@ definitions:
       einmalzahlung:
         type: number
         description: Deprecated. Einmalzahlungen sind Teil der Sonderzahlungen.
+      gesamtLaufzeitInJahren:
+        type: integer
+        format: int32
+        description: nur bei neuen extern berechneten Bausparverträgen
       id:
         type: string
       produktAnbieter:
@@ -1111,6 +1115,11 @@ definitions:
         format: date
       vertragsNummer:
         type: string
+      vertragsPartner:
+        type: array
+        description: nur bei neuen extern berechneten Bausparverträgen
+        items:
+          $ref: '#/definitions/AntragstellerVerknuepfung'
       verwaltungsgebuehrenJaehrlich:
         type: number
       zuteilungsDatum:
@@ -1139,6 +1148,7 @@ definitions:
       gesamtLaufzeitInJahren:
         type: integer
         format: int32
+        description: nur bei neuen extern berechneten Bausparverträgen
       id:
         type: string
       produktAnbieter:
@@ -1593,6 +1603,10 @@ definitions:
         type: integer
         format: int32
         description: nur bei darlehensTyp==FORWARD_DARLEHEN
+      kalkulatorischesLaufzeitEnde:
+        type: string
+        format: date
+        description: bei allen Darlehenstypen außer darlehensTyp==ZWISCHEN_FINANZIERUNG
       kfwEnergieEffizienzStandard:
         type: string
         description: 'nur bei darlehensTyp==KFW_DARLEHEN. Mögliche Werte: STANDARD_40_PLUS, STANDARD_40, STANDARD_55,STANDARD_70. Nur bei KfW-Programm 153 relevant. Bei neuen Energieeffizienzstandards können auch weitere Werte zulässig werden.'


### PR DESCRIPTION
Folgende Daten werden nun ausgegeben:

Bestehende Darlehen, ausser Zwischenfinanzierung:
- Kalkulatorisches Laufzeitende (kalkulatorischesLaufzeitEnde)

Bausparangebot:
- Vertragspartner als Liste
- Gesamtlaufzeit als Integer

Beide Felder werden nur bei von uns berechneten externen
Bausparverträgen in den erfasstenDaten am Vorhaben gefüllt.