### PR TITLE
Release 2.28 - Entscheidungsreife durch den Vertrieb gekennzeichnet

### DIFF
--- a/Dokumentation/index.html
+++ b/Dokumentation/index.html
@@ -579,7 +579,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="sect2">
 <h3 id="_aktuelle_version">Aktuelle Version</h3>
 <div class="paragraph">
-<p><em>Version</em> : 2.27</p>
+<p><em>Version</em> : 2.28</p>
 </div>
 </div>
 <div class="sect2">
@@ -3642,6 +3642,18 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>&lt; <a href="#_dokument">Dokument</a> &gt; array</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>entscheidungsreifeVomVertriebSignalisiert</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Hinweis des Vertriebs, dass der Antrag fertig zur Bearbeitung ist.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>boolean</p>
 </div></div></td>
 </tr>
 <tr>
@@ -11128,7 +11140,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-09-08 10:49:58 +0200
+Last updated 2020-09-15 09:48:23 +0200
 </div>
 </div>
 </body>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Anträge API
 
-##### Aktuelle Version: 2.27
+##### Aktuelle Version: 2.28
 
 [Aktuelles RELEASE](https://github.com/hypoport/antraege-auslesen-api/releases/)
 

--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Securitykontext des Produktanbieters eingenommen.",
-    "version": "2.27",
+    "version": "2.28",
     "title": "Anträge auslesen API",
     "contact": {
       "name": "Europace AG",
@@ -1193,6 +1193,10 @@
           "items": {
             "$ref": "#/definitions/Dokument"
           }
+        },
+        "entscheidungsreifeVomVertriebSignalisiert": {
+          "type": "boolean",
+          "description": "Hinweis des Vertriebs, dass der Antrag fertig zur Bearbeitung ist."
         },
         "kreditSachbearbeiter": {
           "description": "Gewählter Sachbearbeiter aus Seite des Kreditvertriebs",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2,7 +2,7 @@
 swagger: "2.0"
 info:
   description: Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Securitykontext des Produktanbieters eingenommen.
-  version: "2.27"
+  version: "2.28"
   title: Anträge auslesen API
   contact:
     name: Europace AG
@@ -812,6 +812,9 @@ definitions:
         description: Enthält alle Plattformdokumente, freigegebene Dokumente des Vertriebs, sowie die hochgeladenen Dokumente des Produktanbieters.
         items:
           $ref: '#/definitions/Dokument'
+      entscheidungsreifeVomVertriebSignalisiert:
+        type: boolean
+        description: Hinweis des Vertriebs, dass der Antrag fertig zur Bearbeitung ist.
       kreditSachbearbeiter:
         description: Gewählter Sachbearbeiter aus Seite des Kreditvertriebs
         $ref: '#/definitions/Partner'


### PR DESCRIPTION
### Motivation
Der Vertrieb erhält zukünftig die Möglichkeit, seine Anträge als Entscheidungsreif zu markieren. Dieses Flag soll dem Kreditsachbearbeiter anzeigen, dass der Antrag fertig zur Bearbeitung ist.

### Changes
Erweiterung des Antrags um das Flag `entscheidungsreifeVomVertriebSignalisiert`
```json
"antraege": 
[
   {
            "entscheidungsreifeVomVertriebSignalisiert": false,
   }
]

```