### PR TITLE
Release 2.29 - Darlehen erweitern um Attribut konditionsAnpassungsDelta

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13063,7 +13063,13 @@
                             </div>
                         </td>
                         <td class="tableblock halign-left valign-middle">
-                            <div class="content"></div>
+                            <div class="content">
+                                <div class="paragraph">
+                                    <p>true, wenn die Kondition manuell durch den Berater angepasst wurde (d.h. entweder
+                                        Soll- oder Effektivzins des Darlehens, je nachdem welche Anpassung durch den
+                                        Produktanbieter erlaubt ist).</p>
+                                </div>
+                            </div>
                         </td>
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
@@ -13110,7 +13116,9 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Wenn die Kondition manuell angepasst wurde: Delta in Prozentpunkten, um das die
-                                        Kondition angepasst wurde.</p>
+                                        Kondition angepasst wurde (Differenz aus angepasster und ursprünglich
+                                        berechneter Kondition, z.B. angepasst 1,25% - ursprünglich 1,50% = Delta von
+                                        -0,25%).</p>
                                 </div>
                             </div>
                         </td>
@@ -21086,7 +21094,7 @@
 </div>
 <div id="footer">
     <div id="footer-text">
-        Last updated 2020-11-10 15:46:23 +0100
+        Last updated 2020-11-10 17:08:55 +0100
     </div>
 </div>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2400,14 +2400,14 @@
                         </div>
                     </div>
                     <div class="sect4">
-                        <h5 id="_beschreibung_3">Beschreibung</h5>
+                        <h5 id="_beschreibung">Beschreibung</h5>
                         <div class="paragraph">
                             <p>Es werden alle Anträge ausgeliefert, die der authentifizierten Partner sehen darf. Offen:
                                 Sortierung, Pagination, Filterung</p>
                         </div>
                     </div>
                     <div class="sect4">
-                        <h5 id="_parameter_3">Parameter</h5>
+                        <h5 id="_parameter">Parameter</h5>
                         <table class="tableblock frame-all grid-all stretch">
                             <colgroup>
                                 <col style="width: 10%;">
@@ -2842,6 +2842,795 @@
                         </table>
                     </div>
                     <div class="sect4">
+                        <h5 id="_antworten">Antworten</h5>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 10%;">
+                                <col style="width: 70%;">
+                                <col style="width: 20%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-middle">HTTP Code</th>
+                                <th class="tableblock halign-left valign-middle">Beschreibung</th>
+                                <th class="tableblock halign-left valign-middle">Typ</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>200</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>OK</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_antraege">Antraege</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>400</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Client Error</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>401</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Unauthorized</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>403</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Forbidden</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>404</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Not Found</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>422</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Unprocessable Entity</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>500</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Internal Server Error</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_erzeugt">Erzeugt</h5>
+                        <div class="ulist">
+                            <ul>
+                                <li>
+                                    <p><code>application/json;charset=UTF-8</code></p>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_sicherheit">Sicherheit</h5>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 15%;">
+                                <col style="width: 20%;">
+                                <col style="width: 65%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-middle">Typ</th>
+                                <th class="tableblock halign-left valign-middle">Name</th>
+                                <th class="tableblock halign-left valign-middle">Scopes</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>oauth2</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong><a href="#_oauth2">OAuth2</a></strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>baufinanzierung:antrag:lesen</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="_getantraegebyvorgangnummer">Alle Anträge eines Vorgangs abrufen</h4>
+                    <div class="literalblock">
+                        <div class="content">
+                            <pre>GET /v2/antraege/{vorgang}</pre>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_beschreibung_2">Beschreibung</h5>
+                        <div class="paragraph">
+                            <p>Als Parameter wird die Vorgangsnummer in der Form 'AB1234' verwendet.</p>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_parameter_2">Parameter</h5>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 11.1111%;">
+                                <col style="width: 16.6666%;">
+                                <col style="width: 50%;">
+                                <col style="width: 22.2223%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-middle">Typ</th>
+                                <th class="tableblock halign-left valign-middle">Name</th>
+                                <th class="tableblock halign-left valign-middle">Beschreibung</th>
+                                <th class="tableblock halign-left valign-middle">Typ</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Authorization</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>X-Authentication</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>X-TraceId</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Path</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>vorgang</strong><br>
+                                                <em>verpflichtend</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Nummer des Antrags</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_antworten_2">Antworten</h5>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 10%;">
+                                <col style="width: 70%;">
+                                <col style="width: 20%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-middle">HTTP Code</th>
+                                <th class="tableblock halign-left valign-middle">Beschreibung</th>
+                                <th class="tableblock halign-left valign-middle">Typ</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>200</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>OK</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_antraege">Antraege</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>400</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Client Error</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>401</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Unauthorized</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>403</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Forbidden</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>404</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Not Found</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>422</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Unprocessable Entity</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>500</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Internal Server Error</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_erzeugt_2">Erzeugt</h5>
+                        <div class="ulist">
+                            <ul>
+                                <li>
+                                    <p><code>application/json;charset=UTF-8</code></p>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_sicherheit_2">Sicherheit</h5>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 15%;">
+                                <col style="width: 20%;">
+                                <col style="width: 65%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-middle">Typ</th>
+                                <th class="tableblock halign-left valign-middle">Name</th>
+                                <th class="tableblock halign-left valign-middle">Scopes</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>oauth2</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong><a href="#_oauth2">OAuth2</a></strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>baufinanzierung:antrag:lesen</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="_getantrag">Teilanträge eines Antrags abrufen</h4>
+                    <div class="literalblock">
+                        <div class="content">
+                            <pre>GET /v2/antraege/{vorgang}/{antrag}</pre>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_beschreibung_3">Beschreibung</h5>
+                        <div class="paragraph">
+                            <p>Als Parameter wird die Vorgangs- und Antragsnummer in der Form 'AB1234/1' verwendet.</p>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_parameter_3">Parameter</h5>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 11.1111%;">
+                                <col style="width: 16.6666%;">
+                                <col style="width: 50%;">
+                                <col style="width: 22.2223%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-middle">Typ</th>
+                                <th class="tableblock halign-left valign-middle">Name</th>
+                                <th class="tableblock halign-left valign-middle">Beschreibung</th>
+                                <th class="tableblock halign-left valign-middle">Typ</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Authorization</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>X-Authentication</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>X-TraceId</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Path</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>antrag</strong><br>
+                                                <em>verpflichtend</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>antrag</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>integer (int32)</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Path</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>vorgang</strong><br>
+                                                <em>verpflichtend</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Nummer des Antrags</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="sect4">
                         <h5 id="_antworten_3">Antworten</h5>
                         <table class="tableblock frame-all grid-all stretch">
                             <colgroup>
@@ -3075,16 +3864,31 @@
                     </div>
                 </div>
                 <div class="sect3">
-                    <h4 id="_getantraegebyvorgangnummer">Alle Anträge eines Vorgangs abrufen</h4>
+                    <h4 id="_getangebot_1">Angebot des Antrags abrufen</h4>
                     <div class="literalblock">
                         <div class="content">
-                            <pre>GET /v2/antraege/{vorgang}</pre>
+                            <pre>GET /v2/antraege/{vorgang}/{antrag}/angebot</pre>
                         </div>
+                    </div>
+                    <div class="admonitionblock caution">
+                        <table>
+                            <tr>
+                                <td class="icon">
+                                    <div class="title">Caution</div>
+                                </td>
+                                <td class="content">
+                                    <div class="paragraph">
+                                        <p>operation.deprecated</p>
+                                    </div>
+                                </td>
+                            </tr>
+                        </table>
                     </div>
                     <div class="sect4">
                         <h5 id="_beschreibung_4">Beschreibung</h5>
                         <div class="paragraph">
-                            <p>Als Parameter wird die Vorgangsnummer in der Form 'AB1234' verwendet.</p>
+                            <p>Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat. Nutze den
+                                Endpunkt /{vorgang}/{antrag}/{teilAntrag}/angebot</p>
                         </div>
                     </div>
                     <div class="sect4">
@@ -3197,6 +4001,37 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
+                                            <p><strong>antrag</strong><br>
+                                                <em>verpflichtend</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>antrag</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>integer (int32)</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Path</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
                                             <p><strong>vorgang</strong><br>
                                                 <em>verpflichtend</em></p>
                                         </div>
@@ -3205,7 +4040,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Nummer des Antrags</p>
+                                            <p>Nummer des Antrags, bestehend aus Vorgangsnummer und Antragnummer.</p>
                                         </div>
                                     </div>
                                 </td>
@@ -3254,7 +4089,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><a href="#_antraege">Antraege</a></p>
+                                            <p><a href="#_angebotzumantrag">AngebotZumAntrag</a></p>
                                         </div>
                                     </div>
                                 </td>
@@ -3454,16 +4289,16 @@
                     </div>
                 </div>
                 <div class="sect3">
-                    <h4 id="_getantrag">Teilanträge eines Antrags abrufen</h4>
+                    <h4 id="_getantrag_1">Einzelnen Antrag abrufen</h4>
                     <div class="literalblock">
                         <div class="content">
-                            <pre>GET /v2/antraege/{vorgang}/{antrag}</pre>
+                            <pre>GET /v2/antraege/{vorgang}/{antrag}/{teilantrag}</pre>
                         </div>
                     </div>
                     <div class="sect4">
                         <h5 id="_beschreibung_5">Beschreibung</h5>
                         <div class="paragraph">
-                            <p>Als Parameter wird die Vorgangs- und Antragsnummer in der Form 'AB1234/1' verwendet.</p>
+                            <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.</p>
                         </div>
                     </div>
                     <div class="sect4">
@@ -3607,6 +4442,37 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
+                                            <p><strong>teilantrag</strong><br>
+                                                <em>verpflichtend</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>teilantrag</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>integer (int32)</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Path</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
                                             <p><strong>vorgang</strong><br>
                                                 <em>verpflichtend</em></p>
                                         </div>
@@ -3664,7 +4530,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><a href="#_antraege">Antraege</a></p>
+                                            <p><a href="#_antrag">Antrag</a></p>
                                         </div>
                                     </div>
                                 </td>
@@ -3864,31 +4730,17 @@
                     </div>
                 </div>
                 <div class="sect3">
-                    <h4 id="_getangebot_1">Angebot des Antrags abrufen</h4>
+                    <h4 id="_updateantrag">Antrag aktualisieren</h4>
                     <div class="literalblock">
                         <div class="content">
-                            <pre>GET /v2/antraege/{vorgang}/{antrag}/angebot</pre>
+                            <pre>PATCH /v2/antraege/{vorgang}/{antrag}/{teilantrag}</pre>
                         </div>
-                    </div>
-                    <div class="admonitionblock caution">
-                        <table>
-                            <tr>
-                                <td class="icon">
-                                    <div class="title">Caution</div>
-                                </td>
-                                <td class="content">
-                                    <div class="paragraph">
-                                        <p>operation.deprecated</p>
-                                    </div>
-                                </td>
-                            </tr>
-                        </table>
                     </div>
                     <div class="sect4">
                         <h5 id="_beschreibung_6">Beschreibung</h5>
                         <div class="paragraph">
-                            <p>Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat. Nutze den
-                                Endpunkt /{vorgang}/{antrag}/{teilAntrag}/angebot</p>
+                            <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet. Es
+                                können mehrere Operationen gleichzeitig übertragen werden.</p>
                         </div>
                     </div>
                     <div class="sect4">
@@ -3909,87 +4761,6 @@
                             </tr>
                             </thead>
                             <tbody>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Authorization</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>X-Authentication</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>X-TraceId</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
                             <tr>
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
@@ -4032,6 +4803,37 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
+                                            <p><strong>teilantrag</strong><br>
+                                                <em>verpflichtend</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>teilantrag</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>integer (int32)</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Path</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
                                             <p><strong>vorgang</strong><br>
                                                 <em>verpflichtend</em></p>
                                         </div>
@@ -4040,7 +4842,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Nummer des Antrags, bestehend aus Vorgangsnummer und Antragnummer.</p>
+                                            <p>Nummer des Antrags</p>
                                         </div>
                                     </div>
                                 </td>
@@ -4048,6 +4850,37 @@
                                     <div class="content">
                                         <div class="paragraph">
                                             <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Body</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>patchOperations</strong><br>
+                                                <em>verpflichtend</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>patchOperations</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>&lt; <a href="#_patchoperation">PatchOperation</a> &gt; array</p>
                                         </div>
                                     </div>
                                 </td>
@@ -4075,44 +4908,21 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><strong>200</strong></p>
+                                            <p><strong>204</strong></p>
                                         </div>
                                     </div>
                                 </td>
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>OK</p>
+                                            <p>No Content</p>
                                         </div>
                                     </div>
                                 </td>
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><a href="#_angebotzumantrag">AngebotZumAntrag</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>400</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Client Error</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
+                                            <p>Kein Inhalt</p>
                                         </div>
                                     </div>
                                 </td>
@@ -4135,7 +4945,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
+                                            <p>Kein Inhalt</p>
                                         </div>
                                     </div>
                                 </td>
@@ -4158,76 +4968,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>404</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Not Found</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>422</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Unprocessable Entity</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>500</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Internal Server Error</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
+                                            <p>Kein Inhalt</p>
                                         </div>
                                     </div>
                                 </td>
@@ -4236,11 +4977,24 @@
                         </table>
                     </div>
                     <div class="sect4">
+                        <h5 id="_verarbeitet">Verarbeitet</h5>
+                        <div class="ulist">
+                            <ul>
+                                <li>
+                                    <p><code>application/json-patch+json</code></p>
+                                </li>
+                                <li>
+                                    <p><code>application/json</code></p>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="sect4">
                         <h5 id="_erzeugt_6">Erzeugt</h5>
                         <div class="ulist">
                             <ul>
                                 <li>
-                                    <p><code>application/json;charset=UTF-8</code></p>
+                                    <p><code>*/*</code></p>
                                 </li>
                             </ul>
                         </div>
@@ -4279,7 +5033,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>baufinanzierung:antrag:lesen</p>
+                                            <p>baufinanzierung:antrag:schreiben</p>
                                         </div>
                                     </div>
                                 </td>
@@ -4289,16 +5043,16 @@
                     </div>
                 </div>
                 <div class="sect3">
-                    <h4 id="_getantrag_1">Einzelnen Antrag abrufen</h4>
+                    <h4 id="_getangebot">Angebot des Antrags abrufen</h4>
                     <div class="literalblock">
                         <div class="content">
-                            <pre>GET /v2/antraege/{vorgang}/{antrag}/{teilantrag}</pre>
+                            <pre>GET /v2/antraege/{vorgang}/{antrag}/{teilantrag}/angebot</pre>
                         </div>
                     </div>
                     <div class="sect4">
                         <h5 id="_beschreibung_7">Beschreibung</h5>
                         <div class="paragraph">
-                            <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.</p>
+                            <p>Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat.</p>
                         </div>
                     </div>
                     <div class="sect4">
@@ -4481,7 +5235,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Nummer des Antrags</p>
+                                            <p>Nummer des Antrags, bestehend aus Vorgangsnummer und Antragnummer.</p>
                                         </div>
                                     </div>
                                 </td>
@@ -4530,7 +5284,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><a href="#_antrag">Antrag</a></p>
+                                            <p><a href="#_angebotzumantrag">AngebotZumAntrag</a></p>
                                         </div>
                                     </div>
                                 </td>
@@ -4730,17 +5484,17 @@
                     </div>
                 </div>
                 <div class="sect3">
-                    <h4 id="_updateantrag">Antrag aktualisieren</h4>
+                    <h4 id="_getzahlungsplaene">Die Zahlungsplaene (Tilgungs- &amp; Sparpläne) des angenommenen
+                        Angebots.</h4>
                     <div class="literalblock">
                         <div class="content">
-                            <pre>PATCH /v2/antraege/{vorgang}/{antrag}/{teilantrag}</pre>
+                            <pre>GET /v2/antraege/{vorgang}/{antrag}/{teilantrag}/angebot/zahlungsplaene</pre>
                         </div>
                     </div>
                     <div class="sect4">
                         <h5 id="_beschreibung_8">Beschreibung</h5>
                         <div class="paragraph">
-                            <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet. Es
-                                können mehrere Operationen gleichzeitig übertragen werden.</p>
+                            <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.</p>
                         </div>
                     </div>
                     <div class="sect4">
@@ -4765,6 +5519,87 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Authorization</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>X-Authentication</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>X-TraceId</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
                                             <p><strong>Path</strong></p>
                                         </div>
                                     </div>
@@ -4780,7 +5615,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>antrag</p>
+                                            <p>Nummer des Antrags</p>
                                         </div>
                                     </div>
                                 </td>
@@ -4811,7 +5646,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>teilantrag</p>
+                                            <p>Nummer des Teilantrags</p>
                                         </div>
                                     </div>
                                 </td>
@@ -4842,7 +5677,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Nummer des Antrags</p>
+                                            <p>Nummer des Vorgangs</p>
                                         </div>
                                     </div>
                                 </td>
@@ -4850,37 +5685,6 @@
                                     <div class="content">
                                         <div class="paragraph">
                                             <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Body</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>patchOperations</strong><br>
-                                                <em>verpflichtend</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>patchOperations</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>&lt; <a href="#_patchoperation">PatchOperation</a> &gt; array</p>
                                         </div>
                                     </div>
                                 </td>
@@ -4908,21 +5712,44 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><strong>204</strong></p>
+                                            <p><strong>200</strong></p>
                                         </div>
                                     </div>
                                 </td>
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>No Content</p>
+                                            <p>OK</p>
                                         </div>
                                     </div>
                                 </td>
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Kein Inhalt</p>
+                                            <p><a href="#_zahlungsplaene">Zahlungsplaene</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>400</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Client Error</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
                                         </div>
                                     </div>
                                 </td>
@@ -4945,7 +5772,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Kein Inhalt</p>
+                                            <p><a href="#_error">Error</a></p>
                                         </div>
                                     </div>
                                 </td>
@@ -4968,7 +5795,76 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Kein Inhalt</p>
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>404</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Not Found</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>422</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Unprocessable Entity</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>500</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Internal Server Error</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
                                         </div>
                                     </div>
                                 </td>
@@ -4977,24 +5873,11 @@
                         </table>
                     </div>
                     <div class="sect4">
-                        <h5 id="_verarbeitet_3">Verarbeitet</h5>
-                        <div class="ulist">
-                            <ul>
-                                <li>
-                                    <p><code>application/json-patch+json</code></p>
-                                </li>
-                                <li>
-                                    <p><code>application/json</code></p>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="sect4">
                         <h5 id="_erzeugt_8">Erzeugt</h5>
                         <div class="ulist">
                             <ul>
                                 <li>
-                                    <p><code>*/*</code></p>
+                                    <p><code>application/json;charset=UTF-8</code></p>
                                 </li>
                             </ul>
                         </div>
@@ -5033,7 +5916,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>baufinanzierung:antrag:schreiben</p>
+                                            <p>baufinanzierung:antrag:lesen</p>
                                         </div>
                                     </div>
                                 </td>
@@ -5043,16 +5926,16 @@
                     </div>
                 </div>
                 <div class="sect3">
-                    <h4 id="_getangebot">Angebot des Antrags abrufen</h4>
+                    <h4 id="_getansprechpartner">Den Ansprechpartner (Vertrieb) des Teilantrags abrufen.</h4>
                     <div class="literalblock">
                         <div class="content">
-                            <pre>GET /v2/antraege/{vorgang}/{antrag}/{teilantrag}/angebot</pre>
+                            <pre>GET /v2/antraege/{vorgang}/{antrag}/{teilantrag}/ansprechpartner</pre>
                         </div>
                     </div>
                     <div class="sect4">
                         <h5 id="_beschreibung_9">Beschreibung</h5>
                         <div class="paragraph">
-                            <p>Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat.</p>
+                            <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.</p>
                         </div>
                     </div>
                     <div class="sect4">
@@ -5235,7 +6118,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Nummer des Antrags, bestehend aus Vorgangsnummer und Antragnummer.</p>
+                                            <p>Nummer des Antrags</p>
                                         </div>
                                     </div>
                                 </td>
@@ -5284,7 +6167,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><a href="#_angebotzumantrag">AngebotZumAntrag</a></p>
+                                            <p><a href="#_partner">Partner</a></p>
                                         </div>
                                     </div>
                                 </td>
@@ -5484,889 +6367,6 @@
                     </div>
                 </div>
                 <div class="sect3">
-                    <h4 id="_getzahlungsplaene">Die Zahlungsplaene (Tilgungs- &amp; Sparpläne) des angenommenen
-                        Angebots.</h4>
-                    <div class="literalblock">
-                        <div class="content">
-                            <pre>GET /v2/antraege/{vorgang}/{antrag}/{teilantrag}/angebot/zahlungsplaene</pre>
-                        </div>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_beschreibung_10">Beschreibung</h5>
-                        <div class="paragraph">
-                            <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.</p>
-                        </div>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_parameter_10">Parameter</h5>
-                        <table class="tableblock frame-all grid-all stretch">
-                            <colgroup>
-                                <col style="width: 11.1111%;">
-                                <col style="width: 16.6666%;">
-                                <col style="width: 50%;">
-                                <col style="width: 22.2223%;">
-                            </colgroup>
-                            <thead>
-                            <tr>
-                                <th class="tableblock halign-left valign-middle">Typ</th>
-                                <th class="tableblock halign-left valign-middle">Name</th>
-                                <th class="tableblock halign-left valign-middle">Beschreibung</th>
-                                <th class="tableblock halign-left valign-middle">Typ</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Authorization</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>X-Authentication</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>X-TraceId</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Path</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>antrag</strong><br>
-                                                <em>verpflichtend</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Nummer des Antrags</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>integer (int32)</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Path</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>teilantrag</strong><br>
-                                                <em>verpflichtend</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Nummer des Teilantrags</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>integer (int32)</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Path</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>vorgang</strong><br>
-                                                <em>verpflichtend</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Nummer des Vorgangs</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_antworten_10">Antworten</h5>
-                        <table class="tableblock frame-all grid-all stretch">
-                            <colgroup>
-                                <col style="width: 10%;">
-                                <col style="width: 70%;">
-                                <col style="width: 20%;">
-                            </colgroup>
-                            <thead>
-                            <tr>
-                                <th class="tableblock halign-left valign-middle">HTTP Code</th>
-                                <th class="tableblock halign-left valign-middle">Beschreibung</th>
-                                <th class="tableblock halign-left valign-middle">Typ</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>200</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>OK</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_zahlungsplaene">Zahlungsplaene</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>400</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Client Error</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>401</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Unauthorized</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>403</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Forbidden</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>404</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Not Found</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>422</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Unprocessable Entity</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>500</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Internal Server Error</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_erzeugt_10">Erzeugt</h5>
-                        <div class="ulist">
-                            <ul>
-                                <li>
-                                    <p><code>application/json;charset=UTF-8</code></p>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_sicherheit_10">Sicherheit</h5>
-                        <table class="tableblock frame-all grid-all stretch">
-                            <colgroup>
-                                <col style="width: 15%;">
-                                <col style="width: 20%;">
-                                <col style="width: 65%;">
-                            </colgroup>
-                            <thead>
-                            <tr>
-                                <th class="tableblock halign-left valign-middle">Typ</th>
-                                <th class="tableblock halign-left valign-middle">Name</th>
-                                <th class="tableblock halign-left valign-middle">Scopes</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>oauth2</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong><a href="#_oauth2">OAuth2</a></strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>baufinanzierung:antrag:lesen</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="sect3">
-                    <h4 id="_getansprechpartner">Den Ansprechpartner (Vertrieb) des Teilantrags abrufen.</h4>
-                    <div class="literalblock">
-                        <div class="content">
-                            <pre>GET /v2/antraege/{vorgang}/{antrag}/{teilantrag}/ansprechpartner</pre>
-                        </div>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_beschreibung_11">Beschreibung</h5>
-                        <div class="paragraph">
-                            <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.</p>
-                        </div>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_parameter_11">Parameter</h5>
-                        <table class="tableblock frame-all grid-all stretch">
-                            <colgroup>
-                                <col style="width: 11.1111%;">
-                                <col style="width: 16.6666%;">
-                                <col style="width: 50%;">
-                                <col style="width: 22.2223%;">
-                            </colgroup>
-                            <thead>
-                            <tr>
-                                <th class="tableblock halign-left valign-middle">Typ</th>
-                                <th class="tableblock halign-left valign-middle">Name</th>
-                                <th class="tableblock halign-left valign-middle">Beschreibung</th>
-                                <th class="tableblock halign-left valign-middle">Typ</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Authorization</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>X-Authentication</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>X-TraceId</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Path</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>antrag</strong><br>
-                                                <em>verpflichtend</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>antrag</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>integer (int32)</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Path</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>teilantrag</strong><br>
-                                                <em>verpflichtend</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>teilantrag</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>integer (int32)</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Path</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>vorgang</strong><br>
-                                                <em>verpflichtend</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Nummer des Antrags</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_antworten_11">Antworten</h5>
-                        <table class="tableblock frame-all grid-all stretch">
-                            <colgroup>
-                                <col style="width: 10%;">
-                                <col style="width: 70%;">
-                                <col style="width: 20%;">
-                            </colgroup>
-                            <thead>
-                            <tr>
-                                <th class="tableblock halign-left valign-middle">HTTP Code</th>
-                                <th class="tableblock halign-left valign-middle">Beschreibung</th>
-                                <th class="tableblock halign-left valign-middle">Typ</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>200</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>OK</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_partner">Partner</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>400</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Client Error</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>401</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Unauthorized</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>403</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Forbidden</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>404</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Not Found</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>422</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Unprocessable Entity</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>500</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Internal Server Error</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_erzeugt_11">Erzeugt</h5>
-                        <div class="ulist">
-                            <ul>
-                                <li>
-                                    <p><code>application/json;charset=UTF-8</code></p>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_sicherheit_11">Sicherheit</h5>
-                        <table class="tableblock frame-all grid-all stretch">
-                            <colgroup>
-                                <col style="width: 15%;">
-                                <col style="width: 20%;">
-                                <col style="width: 65%;">
-                            </colgroup>
-                            <thead>
-                            <tr>
-                                <th class="tableblock halign-left valign-middle">Typ</th>
-                                <th class="tableblock halign-left valign-middle">Name</th>
-                                <th class="tableblock halign-left valign-middle">Scopes</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>oauth2</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong><a href="#_oauth2">OAuth2</a></strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>baufinanzierung:antrag:lesen</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="sect3">
                     <h4 id="_setantragsstatus_1">Setzen des Antragsstatus</h4>
                     <div class="literalblock">
                         <div class="content">
@@ -6374,7 +6374,7 @@
                         </div>
                     </div>
                     <div class="sect4">
-                        <h5 id="_parameter_12">Parameter</h5>
+                        <h5 id="_parameter_10">Parameter</h5>
                         <table class="tableblock frame-all grid-all stretch">
                             <colgroup>
                                 <col style="width: 11.1111%;">
@@ -6519,7 +6519,7 @@
                         </table>
                     </div>
                     <div class="sect4">
-                        <h5 id="_antworten_12">Antworten</h5>
+                        <h5 id="_antworten_10">Antworten</h5>
                         <table class="tableblock frame-all grid-all stretch">
                             <colgroup>
                                 <col style="width: 10%;">
@@ -6653,7 +6653,7 @@
                         </table>
                     </div>
                     <div class="sect4">
-                        <h5 id="_verarbeitet_4">Verarbeitet</h5>
+                        <h5 id="_verarbeitet_2">Verarbeitet</h5>
                         <div class="ulist">
                             <ul>
                                 <li>
@@ -6663,7 +6663,7 @@
                         </div>
                     </div>
                     <div class="sect4">
-                        <h5 id="_erzeugt_12">Erzeugt</h5>
+                        <h5 id="_erzeugt_10">Erzeugt</h5>
                         <div class="ulist">
                             <ul>
                                 <li>
@@ -6673,7 +6673,7 @@
                         </div>
                     </div>
                     <div class="sect4">
-                        <h5 id="_sicherheit_12">Sicherheit</h5>
+                        <h5 id="_sicherheit_10">Sicherheit</h5>
                         <table class="tableblock frame-all grid-all stretch">
                             <colgroup>
                                 <col style="width: 15%;">
@@ -21086,7 +21086,7 @@
 </div>
 <div id="footer">
     <div id="footer-text">
-        Last updated 2020-11-09 17:52:13 +0100
+        Last updated 2020-11-09 18:41:58 +0100
     </div>
 </div>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -13118,7 +13118,8 @@
                                     <p>Wenn die Kondition manuell angepasst wurde: Delta in Prozentpunkten, um das die
                                         Kondition angepasst wurde (Differenz aus angepasster und ursprünglich
                                         berechneter Kondition, z.B. angepasst 1,25% - ursprünglich 1,50% = Delta von
-                                        -0,25%).</p>
+                                        -0,25%).<br>
+                                        <strong>Beispiel</strong> : <code>-0.25</code></p>
                                 </div>
                             </div>
                         </td>
@@ -21094,7 +21095,7 @@
 </div>
 <div id="footer">
     <div id="footer-text">
-        Last updated 2020-11-10 17:08:55 +0100
+        Last updated 2020-11-10 18:02:18 +0100
     </div>
 </div>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -21086,7 +21086,7 @@
 </div>
 <div id="footer">
     <div id="footer-text">
-        Last updated 2020-11-09 18:41:58 +0100
+        Last updated 2020-11-10 15:46:23 +0100
     </div>
 </div>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2169,7 +2169,8 @@
                             <li><a href="#_updateantrag">Antrag aktualisieren</a></li>
                             <li><a href="#_getangebot">Angebot des Antrags abrufen</a></li>
                             <li><a href="#_getzahlungsplaene">Die Zahlungsplaene (Tilgungs- &amp; Sparpläne) des
-                                angenommenen Angebots.</a></li>
+                                angenommenen
+                                Angebots.</a></li>
                             <li><a href="#_getansprechpartner">Den Ansprechpartner (Vertrieb) des Teilantrags
                                 abrufen.</a></li>
                             <li><a href="#_setantragsstatus_1">Setzen des Antragsstatus</a></li>
@@ -2280,7 +2281,8 @@
         <div class="sectionbody">
             <div class="paragraph">
                 <p>Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird
-                    ausschließlich der Kontext des Produktanbieters eingenommen.</p>
+                    ausschließlich der
+                    Kontext des Produktanbieters eingenommen.</p>
             </div>
             <div class="sect2">
                 <h3 id="_aktuelle_version">Aktuelle Version</h3>
@@ -3888,7 +3890,8 @@
                         <h5 id="_beschreibung_4">Beschreibung</h5>
                         <div class="paragraph">
                             <p>Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat. Nutze den
-                                Endpunkt /{vorgang}/{antrag}/{teilAntrag}/angebot</p>
+                                Endpunkt
+                                /{vorgang}/{antrag}/{teilAntrag}/angebot</p>
                         </div>
                     </div>
                     <div class="sect4">
@@ -4740,7 +4743,8 @@
                         <h5 id="_beschreibung_6">Beschreibung</h5>
                         <div class="paragraph">
                             <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet. Es
-                                können mehrere Operationen gleichzeitig übertragen werden.</p>
+                                können
+                                mehrere Operationen gleichzeitig übertragen werden.</p>
                         </div>
                     </div>
                     <div class="sect4">
@@ -8171,11 +8175,15 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Berufsgruppe des Antragstellers (ING) Diese Angabe ist produktanbieterspezifisch,
-                                        sie wird nicht von allen Produktanbietern bei der Angebotsermittlung
-                                        berücksichtigt.. Erlaubte Werte sind: ANGESTELLTER, ARBEITER, BEAMTER,
-                                        FREIBERUFLER, SELBSTSTAENDIG, RENTNER, HAUSMANN, PRIVATIER, SOLDAT, SCHUELER,
-                                        AZUBI, STUDENT, OHNE. Neue Ausprägungen können kurzfristig hinzukommen. Der
-                                        Client muss daher mit unbekannten Werten umgehen können.</p>
+                                        sie wird
+                                        nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt..
+                                        Erlaubte
+                                        Werte sind: ANGESTELLTER, ARBEITER, BEAMTER, FREIBERUFLER, SELBSTSTAENDIG,
+                                        RENTNER,
+                                        HAUSMANN, PRIVATIER, SOLDAT, SCHUELER, AZUBI, STUDENT, OHNE. Neue Ausprägungen
+                                        können
+                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen
+                                        können.</p>
                                 </div>
                             </div>
                         </td>
@@ -8240,9 +8248,11 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Branchen je Produktanbieter, in welcher der Antragsteller tätig ist. Diese Angabe
-                                        ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der
+                                        ist
+                                        produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der
                                         Angebotsermittlung berücksichtigt. Neue Ausprägungen können kurzfristig
-                                        hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.</p>
+                                        hinzukommen. Der
+                                        Client muss daher mit unbekannten Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -8267,13 +8277,17 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Deprecated. Bitte das Feld 'branche' nutzen. Branche, in welcher der
-                                        Antragsteller tätig ist. (ING) Diese Angabe ist produktanbieterspezifisch, sie
-                                        wird nicht von allen Produktanbietern bei der Angebotsermittlung
-                                        berücksichtigt.. Erlaubte Werte sind: BANKEN_VERSICHERUNGEN, BAUGEWERBE,
-                                        DIENSTLEISTUNGEN_SONSTIGE, EDV_BERATUNG, ENERGIE, ERZIEHUNG_UNTERRICHT,
-                                        GESUNDHEITSWESEN, HANDEL, HANDWERK, HOTEL_GASTRONOMIE, LANDWIRTSCHAFT,
-                                        OEFFENTLICHER_DIENST, PRODUKTION_INDUSTRIE, VERKEHR. Neue Ausprägungen können
-                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen
+                                        Antragsteller tätig
+                                        ist. (ING) Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.. Erlaubte Werte
+                                        sind:
+                                        BANKEN_VERSICHERUNGEN, BAUGEWERBE, DIENSTLEISTUNGEN_SONSTIGE, EDV_BERATUNG,
+                                        ENERGIE,
+                                        ERZIEHUNG_UNTERRICHT, GESUNDHEITSWESEN, HANDEL, HANDWERK, HOTEL_GASTRONOMIE,
+                                        LANDWIRTSCHAFT, OEFFENTLICHER_DIENST, PRODUKTION_INDUSTRIE, VERKEHR. Neue
+                                        Ausprägungen
+                                        können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten
+                                        umgehen
                                         können.</p>
                                 </div>
                             </div>
@@ -8299,12 +8313,15 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Deprecated. Bitte das Feld 'branche' nutzen. Branche, in welcher der
-                                        Antragsteller tätig ist. (MHB) Diese Angabe ist produktanbieterspezifisch, sie
-                                        wird nicht von allen Produktanbietern bei der Angebotsermittlung
-                                        berücksichtigt.. Erlaubte Werte sind: VERARBEITENDES_GEWERBE, BAU, HANDEL,
-                                        VERKEHR_INFORMATION, DIENSTLEISTUNG, SONSTIGES. Neue Ausprägungen können
-                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen
-                                        können.</p>
+                                        Antragsteller tätig
+                                        ist. (MHB) Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.. Erlaubte Werte
+                                        sind:
+                                        VERARBEITENDES_GEWERBE, BAU, HANDEL, VERKEHR_INFORMATION, DIENSTLEISTUNG,
+                                        SONSTIGES. Neue
+                                        Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
+                                        unbekannten Werten
+                                        umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -8329,16 +8346,20 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Deprecated. Bitte das Feld 'branche' nutzen. Branche, in welcher der
-                                        Antragsteller tätig ist. (Sparkassen) Diese Angabe ist
-                                        produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der
-                                        Angebotsermittlung berücksichtigt.. Erlaubte Werte sind: BAUGEWERBE,
-                                        DIENSTLEISTUNGEN, ENERGIE_UND_WASSERVERSORGUNG_BERGBAU,
+                                        Antragsteller tätig
+                                        ist. (Sparkassen) Diese Angabe ist produktanbieterspezifisch, sie wird nicht von
+                                        allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.. Erlaubte Werte
+                                        sind:
+                                        BAUGEWERBE, DIENSTLEISTUNGEN, ENERGIE_UND_WASSERVERSORGUNG_BERGBAU,
                                         GEBIETSKOERPERSCHAFTEN_UND_SOZIALVERSICHERUNGEN, GESUNDHEITSWESEN, HANDEL,
                                         HOTEL_UND_GASTRONOMIE, KREDITINSTITUTE, LAND_UND_FORSTWIRTSCHAFT_FISCHEREI,
                                         OEFFENTLICHER_DIENST, ORGANISATIONEN_OHNE_ERWERBSZWECK_PRIVATE_HAUSHALTE,
                                         VERARBEITENDES_GEWERBE, VERKEHR_UND_NACHRICHTENUEBERMITTLUNG, VERSICHERUNGEN,
-                                        SONSTIGE. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss
-                                        daher mit unbekannten Werten umgehen können.</p>
+                                        SONSTIGE.
+                                        Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
+                                        unbekannten
+                                        Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -8484,8 +8505,9 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt. Relevant für
-                                        Sparprodukte (Bausparkassen).</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt. Relevant für Sparprodukte
+                                        (Bausparkassen).</p>
                                 </div>
                             </div>
                         </td>
@@ -8578,7 +8600,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -10170,7 +10193,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Der Beleihungsauslauf aus Sicht des Produktanbieters. Berechnet sich aus dem
-                                        Verhältnis anerkannter Darlehen zur Summe der anerkannten Beleihungswerte.</p>
+                                        Verhältnis
+                                        anerkannter Darlehen zur Summe der anerkannten Beleihungswerte.</p>
                                 </div>
                             </div>
                         </td>
@@ -10559,7 +10583,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Erlaubte Werte sind: ANGESTELLTER, ARBEITER, ARBEITSLOSER, BEAMTER, FREIBERUFLER,
-                                        HAUSFRAU, RENTNER, SELBSTAENDIGER</p>
+                                        HAUSFRAU,
+                                        RENTNER, SELBSTAENDIGER</p>
                                 </div>
                             </div>
                         </td>
@@ -10803,14 +10828,16 @@
                                         AMBULANTER_KRANKENPFLEGER, ANWALT, APOTHEKER, ARCHITEKT, ARZT, BESTATTER,
                                         DATENSCHUTZBEAUFTRAGTER, DEKORATEUR, DIAETASSISTENT, DOLMETSCHER, EDV_BERATER,
                                         ERGOTHERAPEUT, ERNAEHRUNGSBERATER, FOTOGRAF, GEOGRAF, GRAFIKDESIGNER, GRAFIKER,
-                                        HEBAMME, HEILMASSEUR, HEILPRAKTIKER, HISTORIKER, INFORMATIKER, INGENIEUR,
-                                        INSOLVENZVERWALTER, JOURNALIST, KLASSISCHER_KONZERTMUSIKER, KONSTRUKTEUR,
-                                        KRANKENGYMNAST, KRANKENPFLEGER, KRANKENSCHWESTER, LOGOPAEDE,
-                                        MEDIZINISCH_TECHN_ASSISTENT, NOTAR, OPERNSAENGER, PERSONALBERATER,
-                                        PHYSIOTHERAPEUT, PSYCHOLOGE, RAUMAUSSTATTER, RUNDFUNKSPRECHER,
+                                        HEBAMME,
+                                        HEILMASSEUR, HEILPRAKTIKER, HISTORIKER, INFORMATIKER, INGENIEUR,
+                                        INSOLVENZVERWALTER,
+                                        JOURNALIST, KLASSISCHER_KONZERTMUSIKER, KONSTRUKTEUR, KRANKENGYMNAST,
+                                        KRANKENPFLEGER,
+                                        KRANKENSCHWESTER, LOGOPAEDE, MEDIZINISCH_TECHN_ASSISTENT, NOTAR, OPERNSAENGER,
+                                        PERSONALBERATER, PHYSIOTHERAPEUT, PSYCHOLOGE, RAUMAUSSTATTER, RUNDFUNKSPRECHER,
                                         SACHVERSTAENDIGER, STADTPLANER, STATIKER, STEUERBERATER, TIERARZT,
-                                        UNTERNEHMENSBERATER, VERMITTLER, WIRTSCH_BUCHPRUEFER_REVISOR, ZAHNARZT,
-                                        ZAHNTECHNIKER, SONSTIGES.</p>
+                                        UNTERNEHMENSBERATER,
+                                        VERMITTLER, WIRTSCH_BUCHPRUEFER_REVISOR, ZAHNARZT, ZAHNTECHNIKER, SONSTIGES.</p>
                                 </div>
                             </div>
                         </td>
@@ -10914,7 +10941,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -11059,7 +11087,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -11084,7 +11113,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -11149,7 +11179,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -11174,7 +11205,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -11219,7 +11251,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -11244,9 +11277,12 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.. Erlaubte Werte
-                                        sind: GEHOBEN,MITTEL,EINFACH. Neue Ausprägungen können kurzfristig hinzukommen.
-                                        Der Client muss daher mit unbekannten Werten umgehen können.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.. Erlaubte Werte sind:
+                                        GEHOBEN,MITTEL,EINFACH. Neue
+                                        Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
+                                        unbekannten Werten
+                                        umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -11746,8 +11782,10 @@
                                 <div class="paragraph">
                                     <p>Erlaubte Werte sind:
                                         BAUSPARDARLEHEN,FOERDERDARLEHEN,IMMOBILIENDARLEHEN,PRIVATDARLEHEN,SONSTIGES_DARLEHEN.
-                                        Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
-                                        unbekannten Werten umgehen können.</p>
+                                        Neue
+                                        Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
+                                        unbekannten Werten
+                                        umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -11863,8 +11901,9 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Erlaubte Werte sind: BUCH_GRUNDSCHULD, BRIEF_GRUNDSCHULD. Neue Ausprägungen
-                                        können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten
-                                        umgehen können.</p>
+                                        können
+                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen
+                                        können.</p>
                                 </div>
                             </div>
                         </td>
@@ -11889,7 +11928,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>für DSL Bank Prolongation, d.h. technisch: Produktanbieter ist 'DSL Bank' und
-                                        Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
+                                        Vorhaben
+                                        verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
                                 </div>
                             </div>
                         </td>
@@ -12123,8 +12163,10 @@
                                 <div class="paragraph">
                                     <p>Erlaubte Werte sind:
                                         BAUSPARDARLEHEN,FOERDERDARLEHEN,IMMOBILIENDARLEHEN,PRIVATDARLEHEN,SONSTIGES_DARLEHEN.
-                                        Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
-                                        unbekannten Werten umgehen können.</p>
+                                        Neue
+                                        Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
+                                        unbekannten Werten
+                                        umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -12240,8 +12282,9 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Erlaubte Werte sind: BUCH_GRUNDSCHULD, BRIEF_GRUNDSCHULD. Neue Ausprägungen
-                                        können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten
-                                        umgehen können.</p>
+                                        können
+                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen
+                                        können.</p>
                                 </div>
                             </div>
                         </td>
@@ -12266,7 +12309,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>für DSL Bank Prolongation, d.h. technisch: Produktanbieter ist 'DSL Bank' und
-                                        Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
+                                        Vorhaben
+                                        verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
                                 </div>
                             </div>
                         </td>
@@ -12663,8 +12707,9 @@
                                 <div class="paragraph">
                                     <p>Für Ausprägung ING erlaubte Werte: BANKEN_VERSICHERUNGEN, BAUGEWERBE,
                                         DIENSTLEISTUNGEN_SONSTIGE, EDV_BERATUNG, ENERGIE, ERZIEHUNG_UNTERRICHT,
-                                        GESUNDHEITSWESEN, HANDEL, HANDWERK, HOTEL_GASTRONOMIE, LANDWIRTSCHAFT,
-                                        OEFFENTLICHER_DIENST, PRODUKTION_INDUSTRIE, VERKEHR</p>
+                                        GESUNDHEITSWESEN,
+                                        HANDEL, HANDWERK, HOTEL_GASTRONOMIE, LANDWIRTSCHAFT, OEFFENTLICHER_DIENST,
+                                        PRODUKTION_INDUSTRIE, VERKEHR</p>
                                 </div>
                                 <div class="paragraph">
                                     <p>Für Ausprägung MHB erlaubte Werte: VERARBEITENDES_GEWERBE, BAU, HANDEL,
@@ -12673,11 +12718,11 @@
                                 <div class="paragraph">
                                     <p>Für Ausprägung S_RATING erlaubte Werte: BAUGEWERBE, DIENSTLEISTUNGEN,
                                         ENERGIE_UND_WASSERVERSORGUNG_BERGBAU,
-                                        GEBIETSKOERPERSCHAFTEN_UND_SOZIALVERSICHERUNGEN, GESUNDHEITSWESEN, HANDEL,
-                                        HOTEL_UND_GASTRONOMIE, KREDITINSTITUTE, LAND_UND_FORSTWIRTSCHAFT_FISCHEREI,
-                                        OEFFENTLICHER_DIENST, ORGANISATIONEN_OHNE_ERWERBSZWECK_PRIVATE_HAUSHALTE,
-                                        VERARBEITENDES_GEWERBE, VERKEHR_UND_NACHRICHTENUEBERMITTLUNG, VERSICHERUNGEN,
-                                        SONSTIGE</p>
+                                        GEBIETSKOERPERSCHAFTEN_UND_SOZIALVERSICHERUNGEN,
+                                        GESUNDHEITSWESEN, HANDEL, HOTEL_UND_GASTRONOMIE, KREDITINSTITUTE,
+                                        LAND_UND_FORSTWIRTSCHAFT_FISCHEREI, OEFFENTLICHER_DIENST,
+                                        ORGANISATIONEN_OHNE_ERWERBSZWECK_PRIVATE_HAUSHALTE, VERARBEITENDES_GEWERBE,
+                                        VERKEHR_UND_NACHRICHTENUEBERMITTLUNG, VERSICHERUNGEN, SONSTIGE</p>
                                 </div>
                             </div>
                         </td>
@@ -12746,7 +12791,9 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>nur bei darlehensTyp IN [FORWARD_DARLEHEN,ANNUITAETEN_DARLEHEN]</p>
+                                    <p>Datum, an dem das Darlehen dem Kunden ausgezahlt werden soll. Entweder berechnet
+                                        oder vom
+                                        Kunden angegeben.</p>
                                 </div>
                             </div>
                         </td>
@@ -12858,8 +12905,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>enum (ANNUITAETEN_DARLEHEN, FORWARD_DARLEHEN, KFW_DARLEHEN,
-                                        REGIONAL_FOERDER_DARLEHEN, PRIVAT_DARLEHEN, ZWISCHEN_FINANZIERUNG,
-                                        VARIABLES_DARLEHEN)</p>
+                                        REGIONAL_FOERDER_DARLEHEN,
+                                        PRIVAT_DARLEHEN, ZWISCHEN_FINANZIERUNG, VARIABLES_DARLEHEN)</p>
                                 </div>
                             </div>
                         </td>
@@ -13013,8 +13060,9 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>nur bei darlehensTyp==KFW_DARLEHEN. Mögliche Werte: STANDARD_40_PLUS,
-                                        STANDARD_40, STANDARD_55,STANDARD_70. Nur bei KfW-Programm 153 relevant. Bei
-                                        neuen Energieeffizienzstandards können auch weitere Werte zulässig werden.</p>
+                                        STANDARD_40,
+                                        STANDARD_55,STANDARD_70. Nur bei KfW-Programm 153 relevant. Bei neuen
+                                        Energieeffizienzstandards können auch weitere Werte zulässig werden.</p>
                                 </div>
                             </div>
                         </td>
@@ -13040,8 +13088,8 @@
                                 <div class="paragraph">
                                     <p>nur bei darlehensTyp==KFW_DARLEHEN. Mögliche Werte: PROGRAMM_124, PROGRAMM_141,
                                         PROGRAMM_151, PROGRAMM_152, PROGRAMM_153, PROGRAMM_155, PROGRAMM_159,
-                                        PROGRAMM_167. Bei neu aufgelegten KfW-Programmen können auch weitere Werte
-                                        zulässig werden.</p>
+                                        PROGRAMM_167. Bei
+                                        neu aufgelegten KfW-Programmen können auch weitere Werte zulässig werden.</p>
                                 </div>
                             </div>
                         </td>
@@ -13066,8 +13114,10 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>true, wenn die Kondition manuell durch den Berater angepasst wurde (d.h. entweder
-                                        Soll- oder Effektivzins des Darlehens, je nachdem welche Anpassung durch den
-                                        Produktanbieter erlaubt ist).</p>
+                                        Soll-
+                                        oder Effektivzins des Darlehens, je nachdem welche Anpassung durch den
+                                        Produktanbieter
+                                        erlaubt ist).</p>
                                 </div>
                             </div>
                         </td>
@@ -13116,9 +13166,10 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Wenn die Kondition manuell angepasst wurde: Delta in Prozentpunkten, um das die
-                                        Kondition angepasst wurde (Differenz aus angepasster und ursprünglich
-                                        berechneter Kondition, z.B. angepasst 1,25% - ursprünglich 1,50% = Delta von
-                                        -0,25%).<br>
+                                        Kondition
+                                        angepasst wurde (Differenz aus angepasster und ursprünglich berechneter
+                                        Kondition, z.B.
+                                        angepasst 1,25% - ursprünglich 1,50% = Delta von -0,25%).<br>
                                         <strong>Beispiel</strong> : <code>-0.25</code></p>
                                 </div>
                             </div>
@@ -13309,8 +13360,8 @@
                                     <p>nur bei darlehensTyp==REGIONAL_FOERDER_DARLEHEN. Mögliche Werte:
                                         L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, L_BANK_WOHNEN_MIT_ZUKUNFT,
                                         NRW_BANK_WOHNEIGENTUM. Bei neu aufgelegten Programmen bzw. Aufnahme weiterer
-                                        regionaler Förderbanken in die Plattform können weitere Werte zulässig
-                                        werden.</p>
+                                        regionaler
+                                        Förderbanken in die Plattform können weitere Werte zulässig werden.</p>
                                 </div>
                             </div>
                         </td>
@@ -13458,8 +13509,9 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Die Zinszahlung beginnt zum Abruf des Darlehensbetrages, spätestens jedoch nach
-                                        Ablauf der zinsfreien Zeit. 'zinsZahlungsBeginnAm' liefert das Datum des
-                                        spätensten Zinszahlungsbeginn.</p>
+                                        Ablauf der
+                                        zinsfreien Zeit. 'zinsZahlungsBeginnAm' liefert das Datum des spätensten
+                                        Zinszahlungsbeginn.</p>
                                 </div>
                             </div>
                         </td>
@@ -13596,7 +13648,8 @@
                                 <div class="paragraph">
                                     <p>Mediatype des Dokuments, siehe &lt;a
                                         href="http://tools.ietf.org/html/rfc7231#section-3.1.1.1"&gt;HTTP 1.1: Semantics
-                                        and Content, section 3.1.1.1&lt;/a&gt;</p>
+                                        and
+                                        Content, section 3.1.1.1&lt;/a&gt;</p>
                                 </div>
                             </div>
                         </td>
@@ -14416,7 +14469,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>'null' wenn nicht 'Neubau', anderenfalls: true -&gt; bereits bezahlt, false -
-                                        noch nicht bezahlt</p>
+                                        noch nicht
+                                        bezahlt</p>
                                 </div>
                             </div>
                         </td>
@@ -14761,7 +14815,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -14886,7 +14941,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -14911,7 +14967,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -14956,7 +15013,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -14981,7 +15039,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -15031,7 +15090,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -15056,9 +15116,12 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.. Erlaubte Werte
-                                        sind: GEHOBEN,MITTEL,EINFACH. Neue Ausprägungen können kurzfristig hinzukommen.
-                                        Der Client muss daher mit unbekannten Werten umgehen können.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.. Erlaubte Werte sind:
+                                        GEHOBEN,MITTEL,EINFACH. Neue
+                                        Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
+                                        unbekannten Werten
+                                        umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -15252,9 +15315,9 @@
                                 <div class="paragraph">
                                     <p>Angaben zur Ausstattung für alle verschiedene Produktanbieter und für die für die
                                         automatische Objektbewertungs-Schnittstelle (VDP), aber nicht für ING. Erlaubte
-                                        Werte sind: EINFACH,MITTEL,GEHOBEN,STARK_GEHOBEN. Neue Ausprägungen können
-                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen
-                                        können.</p>
+                                        Werte
+                                        sind: EINFACH,MITTEL,GEHOBEN,STARK_GEHOBEN. Neue Ausprägungen können kurzfristig
+                                        hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -15304,9 +15367,10 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Erlaubte Werte sind:
-                                        FACHWERK_MIT_STROH_LEHM,FACHWERK_MIT_ZIEGELN,GLAS_STAHL,HOLZ,MASSIV. Neue
-                                        Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
-                                        unbekannten Werten umgehen können.</p>
+                                        FACHWERK_MIT_STROH_LEHM,FACHWERK_MIT_ZIEGELN,GLAS_STAHL,HOLZ,MASSIV.
+                                        Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
+                                        unbekannten
+                                        Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -15356,8 +15420,9 @@
                                 <div class="paragraph">
                                     <p>Nur bei ObjektArt == HAUS. Erlaubte Werte sind:
                                         FLACHDACH,NICHT_AUSGEBAUT,TEILWEISE_AUSGEBAUT,VOLL_AUSGEBAUT. Neue Ausprägungen
-                                        können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten
-                                        umgehen können.</p>
+                                        können
+                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen
+                                        können.</p>
                                 </div>
                             </div>
                         </td>
@@ -15495,7 +15560,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Angabe in Kubikmetern. Diese Angabe ist produktanbieterspezifisch, sie wird nicht
-                                        von allen Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -15544,7 +15610,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -15640,7 +15707,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Angaben zum Zustand der Immobilie für die automatische
-                                        Objektbewertungs-Schnittstelle (VDP)</p>
+                                        Objektbewertungs-Schnittstelle
+                                        (VDP)</p>
                                 </div>
                             </div>
                         </td>
@@ -15847,8 +15915,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Belastungen und Beschränkungen in der Nutzbarkeit des Grundstücks.
-                                        Leitungsrechte, Verzichte auf Abstandsflächen, Wegerechte,
-                                        Insolvenzvermerke.</p>
+                                        Leitungsrechte,
+                                        Verzichte auf Abstandsflächen, Wegerechte, Insolvenzvermerke.</p>
                                 </div>
                             </div>
                         </td>
@@ -15965,7 +16033,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -15990,7 +16059,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -16055,7 +16125,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -16100,7 +16171,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt. (DSL Bank)</p>
+                                        Produktanbietern bei
+                                        der Angebotsermittlung berücksichtigt. (DSL Bank)</p>
                                 </div>
                             </div>
                         </td>
@@ -16248,7 +16320,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>&lt; <a href="#_einkuenfteausnebentaetigkeit">EinkuenfteAusNebentaetigkeit</a>
-                                        &gt; array</p>
+                                        &gt; array
+                                    </p>
                                 </div>
                             </div>
                         </td>
@@ -17269,7 +17342,8 @@
                                     <p>Mögliche Werte sind:
                                         AUSZAHLUNGS_VORAUSSETZUNG,MACHBAR,MACHBARKEITS_HINWEIS,ANPASSUNG_KUNDENWUNSCH,ANPASSUNG_VERTRIEBSWUNSCH,UNBERUECKSICHTIGTE_ANGABE,KONDITIONEN_UNTER_VORBEHALT_VOLLSTAENDIGER_DATEN,KONDITIONEN_UNTER_VORBEHALT_EXTERNER_SCHNITTSTELLEN,MACHBARKEIT_UNTER_VORBEHALT_VOLLSTAENDIGER_DATEN,MACHBARKEIT_UNTER_VORBEHALT_EXTERNER_SCHNITTSTELLEN,MACHBAR_UNTER_VORBEHALT_PRODUZENT,NICHT_MACHBAR,NICHT_ANBIETBAR.
                                         Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
-                                        unbekannten Werten umgehen können.</p>
+                                        unbekannten
+                                        Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -17527,8 +17601,9 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Erlaubte Werte sind: UEBERWIEGEND,UMFASSEND,MITTEL,EINFACH. Neue Ausprägungen
-                                        können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten
-                                        umgehen können.</p>
+                                        können
+                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen
+                                        können.</p>
                                 </div>
                             </div>
                         </td>
@@ -17553,8 +17628,10 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Erlaubte Werte sind: KERNSANIERUNG, DACHERNEUERUNG, FENSTER, ROHRLEITUNGEN,
-                                        HEIZUNG, WAERMEDAEMMUNG, BAEDER, INNENAUSBAU, RAUMAUFTEILUNG. Der Client muss
-                                        daher mit unbekannten Werten umgehen können.</p>
+                                        HEIZUNG,
+                                        WAERMEDAEMMUNG, BAEDER, INNENAUSBAU, RAUMAUFTEILUNG. Der Client muss daher mit
+                                        unbekannten
+                                        Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -17562,7 +17639,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>enum (KERNSANIERUNG, DACHERNEUERUNG, FENSTER, ROHRLEITUNGEN, HEIZUNG,
-                                        WAERMEDAEMMUNG, BAEDER, INNENAUSBAU, RAUMAUFTEILUNG)</p>
+                                        WAERMEDAEMMUNG,
+                                        BAEDER, INNENAUSBAU, RAUMAUFTEILUNG)</p>
                                 </div>
                             </div>
                         </td>
@@ -17599,7 +17677,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>erlaubt sind GERING,MITTEL,HOCH. Neue Ausprägungen können kurzfristig
-                                        hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.</p>
+                                        hinzukommen. Der
+                                        Client muss daher mit unbekannten Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -17688,7 +17767,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Der Name des externen Darlehensgebers (Firmierung). Es gibt keine entsprechende
-                                        Beziehung zu einem Partner auf der Europace-Plattform.</p>
+                                        Beziehung
+                                        zu einem Partner auf der Europace-Plattform.</p>
                                 </div>
                             </div>
                         </td>
@@ -17774,8 +17854,10 @@
                                 <div class="paragraph">
                                     <p>Erlaubte Werte sind:
                                         ARBEITGEBERDARLEHEN,BAUSPARDARLEHEN,OEFFENTLICHES_DARLEHEN,RATENKREDIT. Neue
-                                        Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
-                                        unbekannten Werten umgehen können.</p>
+                                        Ausprägungen
+                                        können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten
+                                        umgehen
+                                        können.</p>
                                 </div>
                             </div>
                         </td>
@@ -17882,7 +17964,8 @@
                 <h3 id="_partner">Partner</h3>
                 <div class="paragraph">
                     <p>Minimale Informationen zum Partner der EP2 Plattform, weitere Informationen können über die
-                        HAL-Relation abgerufen werden.</p>
+                        HAL-Relation
+                        abgerufen werden.</p>
                 </div>
                 <table class="tableblock frame-all grid-all stretch">
                     <colgroup>
@@ -18370,7 +18453,8 @@
                                 <div class="paragraph">
                                     <p>JSON-Path im Antrag. Valide Pfade sind: '/antragsReferenz', '/status',
                                         '/status/antragsteller', '/ansprechpartner/partnerId',
-                                        '/status/produktAnbieter', '/voraussichtlicheBearbeitung'.</p>
+                                        '/status/produktAnbieter',
+                                        '/voraussichtlicheBearbeitung'.</p>
                                 </div>
                             </div>
                         </td>
@@ -19152,7 +19236,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Die Ermittlung des Schufa-Scores verzögert sich, wenn sich die Anfrage bei der
-                                        Schufa in manueller Nachbehandlung befindet.</p>
+                                        Schufa in
+                                        manueller Nachbehandlung befindet.</p>
                                 </div>
                             </div>
                         </td>
@@ -19834,7 +19919,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Id des Tilgungsersatzproduktes, das in den Vermögenswerten des Haushalts oder in
-                                        den Bausparangeboten des Angebotes zu finden ist.</p>
+                                        den
+                                        Bausparangeboten des Angebotes zu finden ist.</p>
                                 </div>
                             </div>
                         </td>
@@ -20577,7 +20663,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>&lt; <a href="#_nachrangigesexternesdarlehen">NachrangigesExternesDarlehen</a>
-                                        &gt; array</p>
+                                        &gt; array
+                                    </p>
                                 </div>
                             </div>
                         </td>
@@ -20595,7 +20682,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>enum (ANSCHLUSSFINANZIERUNG, KAUF, KAUF_NEUBAU_VOM_BAUTRAEGER,
-                                        MODERNISIERUNG_UMBAU_ANBAU, NEUBAU, KAPITALBESCHAFFUNG)</p>
+                                        MODERNISIERUNG_UMBAU_ANBAU,
+                                        NEUBAU, KAPITALBESCHAFFUNG)</p>
                                 </div>
                             </div>
                         </td>
@@ -21095,7 +21183,7 @@
 </div>
 <div id="footer">
     <div id="footer-text">
-        Last updated 2020-11-10 18:02:18 +0100
+        Last updated 2020-11-12 09:35:22 +0100
     </div>
 </div>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2168,9 +2168,10 @@
                             <li><a href="#_getantrag_1">Einzelnen Antrag abrufen</a></li>
                             <li><a href="#_updateantrag">Antrag aktualisieren</a></li>
                             <li><a href="#_getangebot">Angebot des Antrags abrufen</a></li>
-                            <li><a href="#_getzahlungsplaene">Die Zahlungsplaene (Tilgungs- &amp; Sparpläne) des angenommenen
-                                Angebots.</a></li>
-                            <li><a href="#_getansprechpartner">Den Ansprechpartner (Vertrieb) des Teilantrags abrufen.</a></li>
+                            <li><a href="#_getzahlungsplaene">Die Zahlungsplaene (Tilgungs- &amp; Sparpläne) des
+                                angenommenen Angebots.</a></li>
+                            <li><a href="#_getansprechpartner">Den Ansprechpartner (Vertrieb) des Teilantrags
+                                abrufen.</a></li>
                             <li><a href="#_setantragsstatus_1">Setzen des Antragsstatus</a></li>
                         </ul>
                     </li>
@@ -2202,7 +2203,8 @@
                     <li><a href="#_bestehendeimmobilie">BestehendeImmobilie</a></li>
                     <li><a href="#_bestehenderbausparvertrag">BestehenderBausparvertrag</a></li>
                     <li><a href="#_bestehendesdarlehen">BestehendesDarlehen</a></li>
-                    <li><a href="#_bestehendesdarlehendesfinanzierungsobjekts">BestehendesDarlehenDesFinanzierungsObjekts</a></li>
+                    <li><a href="#_bestehendesdarlehendesfinanzierungsobjekts">BestehendesDarlehenDesFinanzierungsObjekts</a>
+                    </li>
                     <li><a href="#_bewertungdurchproduktanbieter">BewertungDurchProduktAnbieter</a></li>
                     <li><a href="#_bonitaet">Bonitaet</a></li>
                     <li><a href="#_branche">Branche</a></li>
@@ -2277,20 +2279,21 @@
         <h2 id="_overview">Übersicht</h2>
         <div class="sectionbody">
             <div class="paragraph">
-                <p>Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der
-                    Kontext des Produktanbieters eingenommen.</p>
+                <p>Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird
+                    ausschließlich der Kontext des Produktanbieters eingenommen.</p>
             </div>
             <div class="sect2">
                 <h3 id="_aktuelle_version">Aktuelle Version</h3>
                 <div class="paragraph">
-                    <p><em>Version</em> : 2.28</p>
+                    <p><em>Version</em> : 2.29</p>
                 </div>
             </div>
             <div class="sect2">
                 <h3 id="_kontaktinformationen">Kontaktinformationen</h3>
                 <div class="paragraph">
                     <p><em>Kontakt</em> : Europace AG<br>
-                        <em>Kontakt E-Mail</em> : <a href="mailto:devsupport@europace2.de">devsupport@europace2.de</a></p>
+                        <em>Kontakt E-Mail</em> : <a href="mailto:devsupport@europace2.de">devsupport@europace2.de</a>
+                    </p>
                 </div>
             </div>
             <div class="sect2">
@@ -2355,7 +2358,7 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Lesen eines Antrags oder mehrerer Anträge</p>
+                                    <p>Auslesen von Anträgen</p>
                                 </div>
                             </div>
                         </td>
@@ -2397,14 +2400,14 @@
                         </div>
                     </div>
                     <div class="sect4">
-                        <h5 id="_beschreibung">Beschreibung</h5>
+                        <h5 id="_beschreibung_3">Beschreibung</h5>
                         <div class="paragraph">
                             <p>Es werden alle Anträge ausgeliefert, die der authentifizierten Partner sehen darf. Offen:
                                 Sortierung, Pagination, Filterung</p>
                         </div>
                     </div>
                     <div class="sect4">
-                        <h5 id="_parameter">Parameter</h5>
+                        <h5 id="_parameter_3">Parameter</h5>
                         <table class="tableblock frame-all grid-all stretch">
                             <colgroup>
                                 <col style="width: 10%;">
@@ -2839,795 +2842,6 @@
                         </table>
                     </div>
                     <div class="sect4">
-                        <h5 id="_antworten">Antworten</h5>
-                        <table class="tableblock frame-all grid-all stretch">
-                            <colgroup>
-                                <col style="width: 10%;">
-                                <col style="width: 70%;">
-                                <col style="width: 20%;">
-                            </colgroup>
-                            <thead>
-                            <tr>
-                                <th class="tableblock halign-left valign-middle">HTTP Code</th>
-                                <th class="tableblock halign-left valign-middle">Beschreibung</th>
-                                <th class="tableblock halign-left valign-middle">Typ</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>200</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>OK</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_antraege">Antraege</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>400</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Client Error</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>401</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Unauthorized</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>403</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Forbidden</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>404</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Not Found</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>422</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Unprocessable Entity</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>500</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Internal Server Error</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_erzeugt">Erzeugt</h5>
-                        <div class="ulist">
-                            <ul>
-                                <li>
-                                    <p><code>application/json;charset=UTF-8</code></p>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_sicherheit">Sicherheit</h5>
-                        <table class="tableblock frame-all grid-all stretch">
-                            <colgroup>
-                                <col style="width: 15%;">
-                                <col style="width: 20%;">
-                                <col style="width: 65%;">
-                            </colgroup>
-                            <thead>
-                            <tr>
-                                <th class="tableblock halign-left valign-middle">Typ</th>
-                                <th class="tableblock halign-left valign-middle">Name</th>
-                                <th class="tableblock halign-left valign-middle">Scopes</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>oauth2</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong><a href="#_oauth2">OAuth2</a></strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>baufinanzierung:antrag:lesen</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="sect3">
-                    <h4 id="_getantraegebyvorgangnummer">Alle Anträge eines Vorgangs abrufen</h4>
-                    <div class="literalblock">
-                        <div class="content">
-                            <pre>GET /v2/antraege/{vorgang}</pre>
-                        </div>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_beschreibung_2">Beschreibung</h5>
-                        <div class="paragraph">
-                            <p>Als Parameter wird die Vorgangsnummer in der Form 'AB1234' verwendet.</p>
-                        </div>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_parameter_2">Parameter</h5>
-                        <table class="tableblock frame-all grid-all stretch">
-                            <colgroup>
-                                <col style="width: 11.1111%;">
-                                <col style="width: 16.6666%;">
-                                <col style="width: 50%;">
-                                <col style="width: 22.2223%;">
-                            </colgroup>
-                            <thead>
-                            <tr>
-                                <th class="tableblock halign-left valign-middle">Typ</th>
-                                <th class="tableblock halign-left valign-middle">Name</th>
-                                <th class="tableblock halign-left valign-middle">Beschreibung</th>
-                                <th class="tableblock halign-left valign-middle">Typ</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Authorization</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>X-Authentication</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>X-TraceId</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Path</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>vorgang</strong><br>
-                                                <em>verpflichtend</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Nummer des Antrags</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_antworten_2">Antworten</h5>
-                        <table class="tableblock frame-all grid-all stretch">
-                            <colgroup>
-                                <col style="width: 10%;">
-                                <col style="width: 70%;">
-                                <col style="width: 20%;">
-                            </colgroup>
-                            <thead>
-                            <tr>
-                                <th class="tableblock halign-left valign-middle">HTTP Code</th>
-                                <th class="tableblock halign-left valign-middle">Beschreibung</th>
-                                <th class="tableblock halign-left valign-middle">Typ</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>200</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>OK</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_antraege">Antraege</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>400</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Client Error</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>401</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Unauthorized</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>403</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Forbidden</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>404</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Not Found</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>422</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Unprocessable Entity</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>500</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Internal Server Error</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_erzeugt_2">Erzeugt</h5>
-                        <div class="ulist">
-                            <ul>
-                                <li>
-                                    <p><code>application/json;charset=UTF-8</code></p>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_sicherheit_2">Sicherheit</h5>
-                        <table class="tableblock frame-all grid-all stretch">
-                            <colgroup>
-                                <col style="width: 15%;">
-                                <col style="width: 20%;">
-                                <col style="width: 65%;">
-                            </colgroup>
-                            <thead>
-                            <tr>
-                                <th class="tableblock halign-left valign-middle">Typ</th>
-                                <th class="tableblock halign-left valign-middle">Name</th>
-                                <th class="tableblock halign-left valign-middle">Scopes</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>oauth2</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong><a href="#_oauth2">OAuth2</a></strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>baufinanzierung:antrag:lesen</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="sect3">
-                    <h4 id="_getantrag">Teilanträge eines Antrags abrufen</h4>
-                    <div class="literalblock">
-                        <div class="content">
-                            <pre>GET /v2/antraege/{vorgang}/{antrag}</pre>
-                        </div>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_beschreibung_3">Beschreibung</h5>
-                        <div class="paragraph">
-                            <p>Als Parameter wird die Vorgangs- und Antragsnummer in der Form 'AB1234/1' verwendet.</p>
-                        </div>
-                    </div>
-                    <div class="sect4">
-                        <h5 id="_parameter_3">Parameter</h5>
-                        <table class="tableblock frame-all grid-all stretch">
-                            <colgroup>
-                                <col style="width: 11.1111%;">
-                                <col style="width: 16.6666%;">
-                                <col style="width: 50%;">
-                                <col style="width: 22.2223%;">
-                            </colgroup>
-                            <thead>
-                            <tr>
-                                <th class="tableblock halign-left valign-middle">Typ</th>
-                                <th class="tableblock halign-left valign-middle">Name</th>
-                                <th class="tableblock halign-left valign-middle">Beschreibung</th>
-                                <th class="tableblock halign-left valign-middle">Typ</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Authorization</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>X-Authentication</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>X-TraceId</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Path</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>antrag</strong><br>
-                                                <em>verpflichtend</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>antrag</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>integer (int32)</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Path</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>vorgang</strong><br>
-                                                <em>verpflichtend</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Nummer des Antrags</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                    <div class="sect4">
                         <h5 id="_antworten_3">Antworten</h5>
                         <table class="tableblock frame-all grid-all stretch">
                             <colgroup>
@@ -3861,31 +3075,16 @@
                     </div>
                 </div>
                 <div class="sect3">
-                    <h4 id="_getangebot_1">Angebot des Antrags abrufen</h4>
+                    <h4 id="_getantraegebyvorgangnummer">Alle Anträge eines Vorgangs abrufen</h4>
                     <div class="literalblock">
                         <div class="content">
-                            <pre>GET /v2/antraege/{vorgang}/{antrag}/angebot</pre>
+                            <pre>GET /v2/antraege/{vorgang}</pre>
                         </div>
-                    </div>
-                    <div class="admonitionblock caution">
-                        <table>
-                            <tr>
-                                <td class="icon">
-                                    <div class="title">Caution</div>
-                                </td>
-                                <td class="content">
-                                    <div class="paragraph">
-                                        <p>operation.deprecated</p>
-                                    </div>
-                                </td>
-                            </tr>
-                        </table>
                     </div>
                     <div class="sect4">
                         <h5 id="_beschreibung_4">Beschreibung</h5>
                         <div class="paragraph">
-                            <p>Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat. Nutze den Endpunkt
-                                /{vorgang}/{antrag}/{teilAntrag}/angebot</p>
+                            <p>Als Parameter wird die Vorgangsnummer in der Form 'AB1234' verwendet.</p>
                         </div>
                     </div>
                     <div class="sect4">
@@ -3998,37 +3197,6 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><strong>antrag</strong><br>
-                                                <em>verpflichtend</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>antrag</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>integer (int32)</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Path</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
                                             <p><strong>vorgang</strong><br>
                                                 <em>verpflichtend</em></p>
                                         </div>
@@ -4037,7 +3205,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Nummer des Antrags, bestehend aus Vorgangsnummer und Antragnummer.</p>
+                                            <p>Nummer des Antrags</p>
                                         </div>
                                     </div>
                                 </td>
@@ -4086,7 +3254,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><a href="#_angebotzumantrag">AngebotZumAntrag</a></p>
+                                            <p><a href="#_antraege">Antraege</a></p>
                                         </div>
                                     </div>
                                 </td>
@@ -4286,16 +3454,16 @@
                     </div>
                 </div>
                 <div class="sect3">
-                    <h4 id="_getantrag_1">Einzelnen Antrag abrufen</h4>
+                    <h4 id="_getantrag">Teilanträge eines Antrags abrufen</h4>
                     <div class="literalblock">
                         <div class="content">
-                            <pre>GET /v2/antraege/{vorgang}/{antrag}/{teilantrag}</pre>
+                            <pre>GET /v2/antraege/{vorgang}/{antrag}</pre>
                         </div>
                     </div>
                     <div class="sect4">
                         <h5 id="_beschreibung_5">Beschreibung</h5>
                         <div class="paragraph">
-                            <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.</p>
+                            <p>Als Parameter wird die Vorgangs- und Antragsnummer in der Form 'AB1234/1' verwendet.</p>
                         </div>
                     </div>
                     <div class="sect4">
@@ -4439,37 +3607,6 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><strong>teilantrag</strong><br>
-                                                <em>verpflichtend</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>teilantrag</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>integer (int32)</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Path</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
                                             <p><strong>vorgang</strong><br>
                                                 <em>verpflichtend</em></p>
                                         </div>
@@ -4527,7 +3664,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><a href="#_antrag">Antrag</a></p>
+                                            <p><a href="#_antraege">Antraege</a></p>
                                         </div>
                                     </div>
                                 </td>
@@ -4727,17 +3864,31 @@
                     </div>
                 </div>
                 <div class="sect3">
-                    <h4 id="_updateantrag">Antrag aktualisieren</h4>
+                    <h4 id="_getangebot_1">Angebot des Antrags abrufen</h4>
                     <div class="literalblock">
                         <div class="content">
-                            <pre>PATCH /v2/antraege/{vorgang}/{antrag}/{teilantrag}</pre>
+                            <pre>GET /v2/antraege/{vorgang}/{antrag}/angebot</pre>
                         </div>
+                    </div>
+                    <div class="admonitionblock caution">
+                        <table>
+                            <tr>
+                                <td class="icon">
+                                    <div class="title">Caution</div>
+                                </td>
+                                <td class="content">
+                                    <div class="paragraph">
+                                        <p>operation.deprecated</p>
+                                    </div>
+                                </td>
+                            </tr>
+                        </table>
                     </div>
                     <div class="sect4">
                         <h5 id="_beschreibung_6">Beschreibung</h5>
                         <div class="paragraph">
-                            <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet. Es können
-                                mehrere Operationen gleichzeitig übertragen werden.</p>
+                            <p>Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat. Nutze den
+                                Endpunkt /{vorgang}/{antrag}/{teilAntrag}/angebot</p>
                         </div>
                     </div>
                     <div class="sect4">
@@ -4758,6 +3909,87 @@
                             </tr>
                             </thead>
                             <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Authorization</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>X-Authentication</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>X-TraceId</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
                             <tr>
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
@@ -4800,37 +4032,6 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><strong>teilantrag</strong><br>
-                                                <em>verpflichtend</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>teilantrag</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>integer (int32)</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Path</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
                                             <p><strong>vorgang</strong><br>
                                                 <em>verpflichtend</em></p>
                                         </div>
@@ -4839,7 +4040,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Nummer des Antrags</p>
+                                            <p>Nummer des Antrags, bestehend aus Vorgangsnummer und Antragnummer.</p>
                                         </div>
                                     </div>
                                 </td>
@@ -4847,37 +4048,6 @@
                                     <div class="content">
                                         <div class="paragraph">
                                             <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Body</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>patchOperations</strong><br>
-                                                <em>verpflichtend</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>patchOperations</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>&lt; <a href="#_patchoperation">PatchOperation</a> &gt; array</p>
                                         </div>
                                     </div>
                                 </td>
@@ -4905,21 +4075,44 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><strong>204</strong></p>
+                                            <p><strong>200</strong></p>
                                         </div>
                                     </div>
                                 </td>
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>No Content</p>
+                                            <p>OK</p>
                                         </div>
                                     </div>
                                 </td>
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Kein Inhalt</p>
+                                            <p><a href="#_angebotzumantrag">AngebotZumAntrag</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>400</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Client Error</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
                                         </div>
                                     </div>
                                 </td>
@@ -4942,7 +4135,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Kein Inhalt</p>
+                                            <p><a href="#_error">Error</a></p>
                                         </div>
                                     </div>
                                 </td>
@@ -4965,7 +4158,76 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Kein Inhalt</p>
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>404</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Not Found</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>422</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Unprocessable Entity</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>500</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Internal Server Error</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
                                         </div>
                                     </div>
                                 </td>
@@ -4974,24 +4236,11 @@
                         </table>
                     </div>
                     <div class="sect4">
-                        <h5 id="_verarbeitet">Verarbeitet</h5>
-                        <div class="ulist">
-                            <ul>
-                                <li>
-                                    <p><code>application/json-patch+json</code></p>
-                                </li>
-                                <li>
-                                    <p><code>application/json</code></p>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="sect4">
                         <h5 id="_erzeugt_6">Erzeugt</h5>
                         <div class="ulist">
                             <ul>
                                 <li>
-                                    <p><code>*/*</code></p>
+                                    <p><code>application/json;charset=UTF-8</code></p>
                                 </li>
                             </ul>
                         </div>
@@ -5030,7 +4279,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>baufinanzierung:antrag:schreiben</p>
+                                            <p>baufinanzierung:antrag:lesen</p>
                                         </div>
                                     </div>
                                 </td>
@@ -5040,16 +4289,16 @@
                     </div>
                 </div>
                 <div class="sect3">
-                    <h4 id="_getangebot">Angebot des Antrags abrufen</h4>
+                    <h4 id="_getantrag_1">Einzelnen Antrag abrufen</h4>
                     <div class="literalblock">
                         <div class="content">
-                            <pre>GET /v2/antraege/{vorgang}/{antrag}/{teilantrag}/angebot</pre>
+                            <pre>GET /v2/antraege/{vorgang}/{antrag}/{teilantrag}</pre>
                         </div>
                     </div>
                     <div class="sect4">
                         <h5 id="_beschreibung_7">Beschreibung</h5>
                         <div class="paragraph">
-                            <p>Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat.</p>
+                            <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.</p>
                         </div>
                     </div>
                     <div class="sect4">
@@ -5232,7 +4481,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Nummer des Antrags, bestehend aus Vorgangsnummer und Antragnummer.</p>
+                                            <p>Nummer des Antrags</p>
                                         </div>
                                     </div>
                                 </td>
@@ -5281,7 +4530,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><a href="#_angebotzumantrag">AngebotZumAntrag</a></p>
+                                            <p><a href="#_antrag">Antrag</a></p>
                                         </div>
                                     </div>
                                 </td>
@@ -5481,16 +4730,17 @@
                     </div>
                 </div>
                 <div class="sect3">
-                    <h4 id="_getzahlungsplaene">Die Zahlungsplaene (Tilgungs- &amp; Sparpläne) des angenommenen Angebots.</h4>
+                    <h4 id="_updateantrag">Antrag aktualisieren</h4>
                     <div class="literalblock">
                         <div class="content">
-                            <pre>GET /v2/antraege/{vorgang}/{antrag}/{teilantrag}/angebot/zahlungsplaene</pre>
+                            <pre>PATCH /v2/antraege/{vorgang}/{antrag}/{teilantrag}</pre>
                         </div>
                     </div>
                     <div class="sect4">
                         <h5 id="_beschreibung_8">Beschreibung</h5>
                         <div class="paragraph">
-                            <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.</p>
+                            <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet. Es
+                                können mehrere Operationen gleichzeitig übertragen werden.</p>
                         </div>
                     </div>
                     <div class="sect4">
@@ -5515,87 +4765,6 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Authorization</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>X-Authentication</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>Header</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>X-TraceId</strong><br>
-                                                <em>optional</em></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content"></div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>string</p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
                                             <p><strong>Path</strong></p>
                                         </div>
                                     </div>
@@ -5611,7 +4780,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Nummer des Antrags</p>
+                                            <p>antrag</p>
                                         </div>
                                     </div>
                                 </td>
@@ -5642,7 +4811,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Nummer des Teilantrags</p>
+                                            <p>teilantrag</p>
                                         </div>
                                     </div>
                                 </td>
@@ -5673,7 +4842,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Nummer des Vorgangs</p>
+                                            <p>Nummer des Antrags</p>
                                         </div>
                                     </div>
                                 </td>
@@ -5681,6 +4850,37 @@
                                     <div class="content">
                                         <div class="paragraph">
                                             <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Body</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>patchOperations</strong><br>
+                                                <em>verpflichtend</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>patchOperations</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>&lt; <a href="#_patchoperation">PatchOperation</a> &gt; array</p>
                                         </div>
                                     </div>
                                 </td>
@@ -5708,44 +4908,21 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><strong>200</strong></p>
+                                            <p><strong>204</strong></p>
                                         </div>
                                     </div>
                                 </td>
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>OK</p>
+                                            <p>No Content</p>
                                         </div>
                                     </div>
                                 </td>
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><a href="#_zahlungsplaene">Zahlungsplaene</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>400</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Client Error</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
+                                            <p>Kein Inhalt</p>
                                         </div>
                                     </div>
                                 </td>
@@ -5768,7 +4945,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
+                                            <p>Kein Inhalt</p>
                                         </div>
                                     </div>
                                 </td>
@@ -5791,76 +4968,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>404</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Not Found</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>422</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Unprocessable Entity</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><strong>500</strong></p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p>Internal Server Error</p>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="tableblock halign-left valign-middle">
-                                    <div class="content">
-                                        <div class="paragraph">
-                                            <p><a href="#_error">Error</a></p>
+                                            <p>Kein Inhalt</p>
                                         </div>
                                     </div>
                                 </td>
@@ -5869,11 +4977,24 @@
                         </table>
                     </div>
                     <div class="sect4">
+                        <h5 id="_verarbeitet_3">Verarbeitet</h5>
+                        <div class="ulist">
+                            <ul>
+                                <li>
+                                    <p><code>application/json-patch+json</code></p>
+                                </li>
+                                <li>
+                                    <p><code>application/json</code></p>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="sect4">
                         <h5 id="_erzeugt_8">Erzeugt</h5>
                         <div class="ulist">
                             <ul>
                                 <li>
-                                    <p><code>application/json;charset=UTF-8</code></p>
+                                    <p><code>*/*</code></p>
                                 </li>
                             </ul>
                         </div>
@@ -5912,7 +5033,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>baufinanzierung:antrag:lesen</p>
+                                            <p>baufinanzierung:antrag:schreiben</p>
                                         </div>
                                     </div>
                                 </td>
@@ -5922,16 +5043,16 @@
                     </div>
                 </div>
                 <div class="sect3">
-                    <h4 id="_getansprechpartner">Den Ansprechpartner (Vertrieb) des Teilantrags abrufen.</h4>
+                    <h4 id="_getangebot">Angebot des Antrags abrufen</h4>
                     <div class="literalblock">
                         <div class="content">
-                            <pre>GET /v2/antraege/{vorgang}/{antrag}/{teilantrag}/ansprechpartner</pre>
+                            <pre>GET /v2/antraege/{vorgang}/{antrag}/{teilantrag}/angebot</pre>
                         </div>
                     </div>
                     <div class="sect4">
                         <h5 id="_beschreibung_9">Beschreibung</h5>
                         <div class="paragraph">
-                            <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.</p>
+                            <p>Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat.</p>
                         </div>
                     </div>
                     <div class="sect4">
@@ -6114,7 +5235,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p>Nummer des Antrags</p>
+                                            <p>Nummer des Antrags, bestehend aus Vorgangsnummer und Antragnummer.</p>
                                         </div>
                                     </div>
                                 </td>
@@ -6163,7 +5284,7 @@
                                 <td class="tableblock halign-left valign-middle">
                                     <div class="content">
                                         <div class="paragraph">
-                                            <p><a href="#_partner">Partner</a></p>
+                                            <p><a href="#_angebotzumantrag">AngebotZumAntrag</a></p>
                                         </div>
                                     </div>
                                 </td>
@@ -6363,6 +5484,889 @@
                     </div>
                 </div>
                 <div class="sect3">
+                    <h4 id="_getzahlungsplaene">Die Zahlungsplaene (Tilgungs- &amp; Sparpläne) des angenommenen
+                        Angebots.</h4>
+                    <div class="literalblock">
+                        <div class="content">
+                            <pre>GET /v2/antraege/{vorgang}/{antrag}/{teilantrag}/angebot/zahlungsplaene</pre>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_beschreibung_10">Beschreibung</h5>
+                        <div class="paragraph">
+                            <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.</p>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_parameter_10">Parameter</h5>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 11.1111%;">
+                                <col style="width: 16.6666%;">
+                                <col style="width: 50%;">
+                                <col style="width: 22.2223%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-middle">Typ</th>
+                                <th class="tableblock halign-left valign-middle">Name</th>
+                                <th class="tableblock halign-left valign-middle">Beschreibung</th>
+                                <th class="tableblock halign-left valign-middle">Typ</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Authorization</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>X-Authentication</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>X-TraceId</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Path</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>antrag</strong><br>
+                                                <em>verpflichtend</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Nummer des Antrags</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>integer (int32)</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Path</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>teilantrag</strong><br>
+                                                <em>verpflichtend</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Nummer des Teilantrags</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>integer (int32)</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Path</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>vorgang</strong><br>
+                                                <em>verpflichtend</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Nummer des Vorgangs</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_antworten_10">Antworten</h5>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 10%;">
+                                <col style="width: 70%;">
+                                <col style="width: 20%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-middle">HTTP Code</th>
+                                <th class="tableblock halign-left valign-middle">Beschreibung</th>
+                                <th class="tableblock halign-left valign-middle">Typ</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>200</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>OK</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_zahlungsplaene">Zahlungsplaene</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>400</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Client Error</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>401</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Unauthorized</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>403</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Forbidden</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>404</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Not Found</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>422</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Unprocessable Entity</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>500</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Internal Server Error</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_erzeugt_10">Erzeugt</h5>
+                        <div class="ulist">
+                            <ul>
+                                <li>
+                                    <p><code>application/json;charset=UTF-8</code></p>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_sicherheit_10">Sicherheit</h5>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 15%;">
+                                <col style="width: 20%;">
+                                <col style="width: 65%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-middle">Typ</th>
+                                <th class="tableblock halign-left valign-middle">Name</th>
+                                <th class="tableblock halign-left valign-middle">Scopes</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>oauth2</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong><a href="#_oauth2">OAuth2</a></strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>baufinanzierung:antrag:lesen</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="_getansprechpartner">Den Ansprechpartner (Vertrieb) des Teilantrags abrufen.</h4>
+                    <div class="literalblock">
+                        <div class="content">
+                            <pre>GET /v2/antraege/{vorgang}/{antrag}/{teilantrag}/ansprechpartner</pre>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_beschreibung_11">Beschreibung</h5>
+                        <div class="paragraph">
+                            <p>Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.</p>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_parameter_11">Parameter</h5>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 11.1111%;">
+                                <col style="width: 16.6666%;">
+                                <col style="width: 50%;">
+                                <col style="width: 22.2223%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-middle">Typ</th>
+                                <th class="tableblock halign-left valign-middle">Name</th>
+                                <th class="tableblock halign-left valign-middle">Beschreibung</th>
+                                <th class="tableblock halign-left valign-middle">Typ</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Authorization</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>X-Authentication</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Header</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>X-TraceId</strong><br>
+                                                <em>optional</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content"></div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Path</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>antrag</strong><br>
+                                                <em>verpflichtend</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>antrag</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>integer (int32)</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Path</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>teilantrag</strong><br>
+                                                <em>verpflichtend</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>teilantrag</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>integer (int32)</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>Path</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>vorgang</strong><br>
+                                                <em>verpflichtend</em></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Nummer des Antrags</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>string</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_antworten_11">Antworten</h5>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 10%;">
+                                <col style="width: 70%;">
+                                <col style="width: 20%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-middle">HTTP Code</th>
+                                <th class="tableblock halign-left valign-middle">Beschreibung</th>
+                                <th class="tableblock halign-left valign-middle">Typ</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>200</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>OK</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_partner">Partner</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>400</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Client Error</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>401</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Unauthorized</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>403</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Forbidden</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>404</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Not Found</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>422</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Unprocessable Entity</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>500</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>Internal Server Error</p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><a href="#_error">Error</a></p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_erzeugt_11">Erzeugt</h5>
+                        <div class="ulist">
+                            <ul>
+                                <li>
+                                    <p><code>application/json;charset=UTF-8</code></p>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_sicherheit_11">Sicherheit</h5>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 15%;">
+                                <col style="width: 20%;">
+                                <col style="width: 65%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-middle">Typ</th>
+                                <th class="tableblock halign-left valign-middle">Name</th>
+                                <th class="tableblock halign-left valign-middle">Scopes</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong>oauth2</strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p><strong><a href="#_oauth2">OAuth2</a></strong></p>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="tableblock halign-left valign-middle">
+                                    <div class="content">
+                                        <div class="paragraph">
+                                            <p>baufinanzierung:antrag:lesen</p>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="sect3">
                     <h4 id="_setantragsstatus_1">Setzen des Antragsstatus</h4>
                     <div class="literalblock">
                         <div class="content">
@@ -6370,7 +6374,7 @@
                         </div>
                     </div>
                     <div class="sect4">
-                        <h5 id="_parameter_10">Parameter</h5>
+                        <h5 id="_parameter_12">Parameter</h5>
                         <table class="tableblock frame-all grid-all stretch">
                             <colgroup>
                                 <col style="width: 11.1111%;">
@@ -6515,7 +6519,7 @@
                         </table>
                     </div>
                     <div class="sect4">
-                        <h5 id="_antworten_10">Antworten</h5>
+                        <h5 id="_antworten_12">Antworten</h5>
                         <table class="tableblock frame-all grid-all stretch">
                             <colgroup>
                                 <col style="width: 10%;">
@@ -6649,7 +6653,7 @@
                         </table>
                     </div>
                     <div class="sect4">
-                        <h5 id="_verarbeitet_2">Verarbeitet</h5>
+                        <h5 id="_verarbeitet_4">Verarbeitet</h5>
                         <div class="ulist">
                             <ul>
                                 <li>
@@ -6659,7 +6663,7 @@
                         </div>
                     </div>
                     <div class="sect4">
-                        <h5 id="_erzeugt_10">Erzeugt</h5>
+                        <h5 id="_erzeugt_12">Erzeugt</h5>
                         <div class="ulist">
                             <ul>
                                 <li>
@@ -6669,7 +6673,7 @@
                         </div>
                     </div>
                     <div class="sect4">
-                        <h5 id="_sicherheit_10">Sicherheit</h5>
+                        <h5 id="_sicherheit_12">Sicherheit</h5>
                         <table class="tableblock frame-all grid-all stretch">
                             <colgroup>
                                 <col style="width: 15%;">
@@ -7178,7 +7182,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>&lt; <a href="#_angebotspruefungsergebnis">AngebotsPruefungsErgebnis</a> &gt; array</p>
+                                    <p>&lt; <a href="#_angebotspruefungsergebnis">AngebotsPruefungsErgebnis</a> &gt;
+                                        array</p>
                                 </div>
                             </div>
                         </td>
@@ -7448,7 +7453,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Für Rückfragen auf Seite des Vertriebs, kann mit dem Vermittler identisch sein</p>
+                                    <p>Für Rückfragen auf Seite des Vertriebs, kann mit dem Vermittler identisch
+                                        sein</p>
                                 </div>
                             </div>
                         </td>
@@ -7544,7 +7550,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Gibt an, ob es sich um einen Antrag aus dem Testmodus oder Echtgeschäft handelt</p>
+                                    <p>Gibt an, ob es sich um einen Antrag aus dem Testmodus oder Echtgeschäft
+                                        handelt</p>
                                 </div>
                             </div>
                         </td>
@@ -8121,7 +8128,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>enum (VISUM, AUFENTHALTS_ERLAUBNIS, NIEDERLASSUNGS_ERLAUBNIS, DAUERAUFENTHALT_EU)</p>
+                                    <p>enum (VISUM, AUFENTHALTS_ERLAUBNIS, NIEDERLASSUNGS_ERLAUBNIS,
+                                        DAUERAUFENTHALT_EU)</p>
                                 </div>
                             </div>
                         </td>
@@ -8162,11 +8170,12 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Berufsgruppe des Antragstellers (ING) Diese Angabe ist produktanbieterspezifisch, sie wird
-                                        nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt.. Erlaubte
-                                        Werte sind: ANGESTELLTER, ARBEITER, BEAMTER, FREIBERUFLER, SELBSTSTAENDIG, RENTNER,
-                                        HAUSMANN, PRIVATIER, SOLDAT, SCHUELER, AZUBI, STUDENT, OHNE. Neue Ausprägungen können
-                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.</p>
+                                    <p>Berufsgruppe des Antragstellers (ING) Diese Angabe ist produktanbieterspezifisch,
+                                        sie wird nicht von allen Produktanbietern bei der Angebotsermittlung
+                                        berücksichtigt.. Erlaubte Werte sind: ANGESTELLTER, ARBEITER, BEAMTER,
+                                        FREIBERUFLER, SELBSTSTAENDIG, RENTNER, HAUSMANN, PRIVATIER, SOLDAT, SCHUELER,
+                                        AZUBI, STUDENT, OHNE. Neue Ausprägungen können kurzfristig hinzukommen. Der
+                                        Client muss daher mit unbekannten Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -8230,10 +8239,10 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Branchen je Produktanbieter, in welcher der Antragsteller tätig ist. Diese Angabe ist
-                                        produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der
-                                        Angebotsermittlung berücksichtigt. Neue Ausprägungen können kurzfristig hinzukommen. Der
-                                        Client muss daher mit unbekannten Werten umgehen können.</p>
+                                    <p>Branchen je Produktanbieter, in welcher der Antragsteller tätig ist. Diese Angabe
+                                        ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der
+                                        Angebotsermittlung berücksichtigt. Neue Ausprägungen können kurzfristig
+                                        hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -8257,13 +8266,14 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Deprecated. Bitte das Feld 'branche' nutzen. Branche, in welcher der Antragsteller tätig
-                                        ist. (ING) Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.. Erlaubte Werte sind:
-                                        BANKEN_VERSICHERUNGEN, BAUGEWERBE, DIENSTLEISTUNGEN_SONSTIGE, EDV_BERATUNG, ENERGIE,
-                                        ERZIEHUNG_UNTERRICHT, GESUNDHEITSWESEN, HANDEL, HANDWERK, HOTEL_GASTRONOMIE,
-                                        LANDWIRTSCHAFT, OEFFENTLICHER_DIENST, PRODUKTION_INDUSTRIE, VERKEHR. Neue Ausprägungen
-                                        können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen
+                                    <p>Deprecated. Bitte das Feld 'branche' nutzen. Branche, in welcher der
+                                        Antragsteller tätig ist. (ING) Diese Angabe ist produktanbieterspezifisch, sie
+                                        wird nicht von allen Produktanbietern bei der Angebotsermittlung
+                                        berücksichtigt.. Erlaubte Werte sind: BANKEN_VERSICHERUNGEN, BAUGEWERBE,
+                                        DIENSTLEISTUNGEN_SONSTIGE, EDV_BERATUNG, ENERGIE, ERZIEHUNG_UNTERRICHT,
+                                        GESUNDHEITSWESEN, HANDEL, HANDWERK, HOTEL_GASTRONOMIE, LANDWIRTSCHAFT,
+                                        OEFFENTLICHER_DIENST, PRODUKTION_INDUSTRIE, VERKEHR. Neue Ausprägungen können
+                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen
                                         können.</p>
                                 </div>
                             </div>
@@ -8288,12 +8298,13 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Deprecated. Bitte das Feld 'branche' nutzen. Branche, in welcher der Antragsteller tätig
-                                        ist. (MHB) Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.. Erlaubte Werte sind:
-                                        VERARBEITENDES_GEWERBE, BAU, HANDEL, VERKEHR_INFORMATION, DIENSTLEISTUNG, SONSTIGES. Neue
-                                        Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten
-                                        umgehen können.</p>
+                                    <p>Deprecated. Bitte das Feld 'branche' nutzen. Branche, in welcher der
+                                        Antragsteller tätig ist. (MHB) Diese Angabe ist produktanbieterspezifisch, sie
+                                        wird nicht von allen Produktanbietern bei der Angebotsermittlung
+                                        berücksichtigt.. Erlaubte Werte sind: VERARBEITENDES_GEWERBE, BAU, HANDEL,
+                                        VERKEHR_INFORMATION, DIENSTLEISTUNG, SONSTIGES. Neue Ausprägungen können
+                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen
+                                        können.</p>
                                 </div>
                             </div>
                         </td>
@@ -8317,16 +8328,17 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Deprecated. Bitte das Feld 'branche' nutzen. Branche, in welcher der Antragsteller tätig
-                                        ist. (Sparkassen) Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.. Erlaubte Werte sind:
-                                        BAUGEWERBE, DIENSTLEISTUNGEN, ENERGIE_UND_WASSERVERSORGUNG_BERGBAU,
+                                    <p>Deprecated. Bitte das Feld 'branche' nutzen. Branche, in welcher der
+                                        Antragsteller tätig ist. (Sparkassen) Diese Angabe ist
+                                        produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der
+                                        Angebotsermittlung berücksichtigt.. Erlaubte Werte sind: BAUGEWERBE,
+                                        DIENSTLEISTUNGEN, ENERGIE_UND_WASSERVERSORGUNG_BERGBAU,
                                         GEBIETSKOERPERSCHAFTEN_UND_SOZIALVERSICHERUNGEN, GESUNDHEITSWESEN, HANDEL,
                                         HOTEL_UND_GASTRONOMIE, KREDITINSTITUTE, LAND_UND_FORSTWIRTSCHAFT_FISCHEREI,
                                         OEFFENTLICHER_DIENST, ORGANISATIONEN_OHNE_ERWERBSZWECK_PRIVATE_HAUSHALTE,
-                                        VERARBEITENDES_GEWERBE, VERKEHR_UND_NACHRICHTENUEBERMITTLUNG, VERSICHERUNGEN, SONSTIGE.
-                                        Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten
-                                        Werten umgehen können.</p>
+                                        VERARBEITENDES_GEWERBE, VERKEHR_UND_NACHRICHTENUEBERMITTLUNG, VERSICHERUNGEN,
+                                        SONSTIGE. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss
+                                        daher mit unbekannten Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -8433,7 +8445,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>enum (GESCHIEDEN, GETRENNT_LEBEND, LEBENSPARTNERSCHAFT, LEDIG, VERHEIRATET, VERWITWET)</p>
+                                    <p>enum (GESCHIEDEN, GETRENNT_LEBEND, LEBENSPARTNERSCHAFT, LEDIG, VERHEIRATET,
+                                        VERWITWET)</p>
                                 </div>
                             </div>
                         </td>
@@ -8470,8 +8483,9 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt. Relevant für Sparprodukte (Bausparkassen).</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt. Relevant für
+                                        Sparprodukte (Bausparkassen).</p>
                                 </div>
                             </div>
                         </td>
@@ -8563,8 +8577,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -9658,7 +9672,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>&lt; <a href="#_antragstellerverknuepfung">AntragstellerVerknuepfung</a> &gt; array</p>
+                                    <p>&lt; <a href="#_antragstellerverknuepfung">AntragstellerVerknuepfung</a> &gt;
+                                        array</p>
                                 </div>
                             </div>
                         </td>
@@ -10077,7 +10092,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>&lt; <a href="#_antragstellerverknuepfung">AntragstellerVerknuepfung</a> &gt; array</p>
+                                    <p>&lt; <a href="#_antragstellerverknuepfung">AntragstellerVerknuepfung</a> &gt;
+                                        array</p>
                                 </div>
                             </div>
                         </td>
@@ -10153,8 +10169,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Der Beleihungsauslauf aus Sicht des Produktanbieters. Berechnet sich aus dem Verhältnis
-                                        anerkannter Darlehen zur Summe der anerkannten Beleihungswerte.</p>
+                                    <p>Der Beleihungsauslauf aus Sicht des Produktanbieters. Berechnet sich aus dem
+                                        Verhältnis anerkannter Darlehen zur Summe der anerkannten Beleihungswerte.</p>
                                 </div>
                             </div>
                         </td>
@@ -10202,7 +10218,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Berechnungshilfe: Die Summe aller vom Produktanbieter anerkannten Beleihungswerte</p>
+                                    <p>Berechnungshilfe: Die Summe aller vom Produktanbieter anerkannten
+                                        Beleihungswerte</p>
                                 </div>
                             </div>
                         </td>
@@ -10336,7 +10353,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>enum (PRAESENZ_GESCHAEFT, FERN_ABSATZ_GESCHAEFT, AUSSER_GESCHAEFTSRAUM_VERTRAG)</p>
+                                    <p>enum (PRAESENZ_GESCHAEFT, FERN_ABSATZ_GESCHAEFT,
+                                        AUSSER_GESCHAEFTSRAUM_VERTRAG)</p>
                                 </div>
                             </div>
                         </td>
@@ -10373,7 +10391,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Mit diesem Wert wird ausgedrückt, ob der Kundenbetreuer auch der Immobilienmakler ist.</p>
+                                    <p>Mit diesem Wert wird ausgedrückt, ob der Kundenbetreuer auch der Immobilienmakler
+                                        ist.</p>
                                 </div>
                             </div>
                         </td>
@@ -10539,8 +10558,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Erlaubte Werte sind: ANGESTELLTER, ARBEITER, ARBEITSLOSER, BEAMTER, FREIBERUFLER, HAUSFRAU,
-                                        RENTNER, SELBSTAENDIGER</p>
+                                    <p>Erlaubte Werte sind: ANGESTELLTER, ARBEITER, ARBEITSLOSER, BEAMTER, FREIBERUFLER,
+                                        HAUSFRAU, RENTNER, SELBSTAENDIGER</p>
                                 </div>
                             </div>
                         </td>
@@ -10783,13 +10802,15 @@
                                     <p>nur bei art==FREIBERUFLER,SELBSTAENDIGER. Erlaubte Werte sind: ALTENPFLEGER,
                                         AMBULANTER_KRANKENPFLEGER, ANWALT, APOTHEKER, ARCHITEKT, ARZT, BESTATTER,
                                         DATENSCHUTZBEAUFTRAGTER, DEKORATEUR, DIAETASSISTENT, DOLMETSCHER, EDV_BERATER,
-                                        ERGOTHERAPEUT, ERNAEHRUNGSBERATER, FOTOGRAF, GEOGRAF, GRAFIKDESIGNER, GRAFIKER, HEBAMME,
-                                        HEILMASSEUR, HEILPRAKTIKER, HISTORIKER, INFORMATIKER, INGENIEUR, INSOLVENZVERWALTER,
-                                        JOURNALIST, KLASSISCHER_KONZERTMUSIKER, KONSTRUKTEUR, KRANKENGYMNAST, KRANKENPFLEGER,
-                                        KRANKENSCHWESTER, LOGOPAEDE, MEDIZINISCH_TECHN_ASSISTENT, NOTAR, OPERNSAENGER,
-                                        PERSONALBERATER, PHYSIOTHERAPEUT, PSYCHOLOGE, RAUMAUSSTATTER, RUNDFUNKSPRECHER,
-                                        SACHVERSTAENDIGER, STADTPLANER, STATIKER, STEUERBERATER, TIERARZT, UNTERNEHMENSBERATER,
-                                        VERMITTLER, WIRTSCH_BUCHPRUEFER_REVISOR, ZAHNARZT, ZAHNTECHNIKER, SONSTIGES.</p>
+                                        ERGOTHERAPEUT, ERNAEHRUNGSBERATER, FOTOGRAF, GEOGRAF, GRAFIKDESIGNER, GRAFIKER,
+                                        HEBAMME, HEILMASSEUR, HEILPRAKTIKER, HISTORIKER, INFORMATIKER, INGENIEUR,
+                                        INSOLVENZVERWALTER, JOURNALIST, KLASSISCHER_KONZERTMUSIKER, KONSTRUKTEUR,
+                                        KRANKENGYMNAST, KRANKENPFLEGER, KRANKENSCHWESTER, LOGOPAEDE,
+                                        MEDIZINISCH_TECHN_ASSISTENT, NOTAR, OPERNSAENGER, PERSONALBERATER,
+                                        PHYSIOTHERAPEUT, PSYCHOLOGE, RAUMAUSSTATTER, RUNDFUNKSPRECHER,
+                                        SACHVERSTAENDIGER, STADTPLANER, STATIKER, STEUERBERATER, TIERARZT,
+                                        UNTERNEHMENSBERATER, VERMITTLER, WIRTSCH_BUCHPRUEFER_REVISOR, ZAHNARZT,
+                                        ZAHNTECHNIKER, SONSTIGES.</p>
                                 </div>
                             </div>
                         </td>
@@ -10892,8 +10913,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -11037,8 +11058,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -11062,8 +11083,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -11127,8 +11148,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -11152,8 +11173,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -11197,8 +11218,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -11222,10 +11243,10 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.. Erlaubte Werte sind: GEHOBEN,MITTEL,EINFACH. Neue
-                                        Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten
-                                        umgehen können.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.. Erlaubte Werte
+                                        sind: GEHOBEN,MITTEL,EINFACH. Neue Ausprägungen können kurzfristig hinzukommen.
+                                        Der Client muss daher mit unbekannten Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -11724,9 +11745,9 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Erlaubte Werte sind:
-                                        BAUSPARDARLEHEN,FOERDERDARLEHEN,IMMOBILIENDARLEHEN,PRIVATDARLEHEN,SONSTIGES_DARLEHEN. Neue
-                                        Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten
-                                        umgehen können.</p>
+                                        BAUSPARDARLEHEN,FOERDERDARLEHEN,IMMOBILIENDARLEHEN,PRIVATDARLEHEN,SONSTIGES_DARLEHEN.
+                                        Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
+                                        unbekannten Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -11751,7 +11772,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>für Prolongation, d.h. technisch: Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
+                                    <p>für Prolongation, d.h. technisch: Vorhaben
+                                        verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
                                 </div>
                             </div>
                         </td>
@@ -11795,7 +11817,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>für Prolongation, d.h. technisch: Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
+                                    <p>für Prolongation, d.h. technisch: Vorhaben
+                                        verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
                                 </div>
                             </div>
                         </td>
@@ -11839,8 +11862,9 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Erlaubte Werte sind: BUCH_GRUNDSCHULD, BRIEF_GRUNDSCHULD. Neue Ausprägungen können
-                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.</p>
+                                    <p>Erlaubte Werte sind: BUCH_GRUNDSCHULD, BRIEF_GRUNDSCHULD. Neue Ausprägungen
+                                        können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten
+                                        umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -11864,8 +11888,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>für DSL Bank Prolongation, d.h. technisch: Produktanbieter ist 'DSL Bank' und Vorhaben
-                                        verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
+                                    <p>für DSL Bank Prolongation, d.h. technisch: Produktanbieter ist 'DSL Bank' und
+                                        Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
                                 </div>
                             </div>
                         </td>
@@ -11969,7 +11993,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>für Prolongation, d.h. technisch: Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
+                                    <p>für Prolongation, d.h. technisch: Vorhaben
+                                        verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
                                 </div>
                             </div>
                         </td>
@@ -12097,9 +12122,9 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Erlaubte Werte sind:
-                                        BAUSPARDARLEHEN,FOERDERDARLEHEN,IMMOBILIENDARLEHEN,PRIVATDARLEHEN,SONSTIGES_DARLEHEN. Neue
-                                        Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten
-                                        umgehen können.</p>
+                                        BAUSPARDARLEHEN,FOERDERDARLEHEN,IMMOBILIENDARLEHEN,PRIVATDARLEHEN,SONSTIGES_DARLEHEN.
+                                        Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
+                                        unbekannten Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -12124,7 +12149,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>für Prolongation, d.h. technisch: Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
+                                    <p>für Prolongation, d.h. technisch: Vorhaben
+                                        verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
                                 </div>
                             </div>
                         </td>
@@ -12168,7 +12194,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>für Prolongation, d.h. technisch: Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
+                                    <p>für Prolongation, d.h. technisch: Vorhaben
+                                        verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
                                 </div>
                             </div>
                         </td>
@@ -12212,8 +12239,9 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Erlaubte Werte sind: BUCH_GRUNDSCHULD, BRIEF_GRUNDSCHULD. Neue Ausprägungen können
-                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.</p>
+                                    <p>Erlaubte Werte sind: BUCH_GRUNDSCHULD, BRIEF_GRUNDSCHULD. Neue Ausprägungen
+                                        können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten
+                                        umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -12237,8 +12265,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>für DSL Bank Prolongation, d.h. technisch: Produktanbieter ist 'DSL Bank' und Vorhaben
-                                        verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
+                                    <p>für DSL Bank Prolongation, d.h. technisch: Produktanbieter ist 'DSL Bank' und
+                                        Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
                                 </div>
                             </div>
                         </td>
@@ -12342,7 +12370,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>für Prolongation, d.h. technisch: Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
+                                    <p>für Prolongation, d.h. technisch: Vorhaben
+                                        verwendungszweck==ANSCHLUSSFINANZIERUNG</p>
                                 </div>
                             </div>
                         </td>
@@ -12366,7 +12395,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Beschreibt wie das Darlehen im Zusammenhang mit dem Vorhaben, behandelt werden soll.</p>
+                                    <p>Beschreibt wie das Darlehen im Zusammenhang mit dem Vorhaben, behandelt werden
+                                        soll.</p>
                                 </div>
                             </div>
                         </td>
@@ -12632,9 +12662,9 @@
                                 </div>
                                 <div class="paragraph">
                                     <p>Für Ausprägung ING erlaubte Werte: BANKEN_VERSICHERUNGEN, BAUGEWERBE,
-                                        DIENSTLEISTUNGEN_SONSTIGE, EDV_BERATUNG, ENERGIE, ERZIEHUNG_UNTERRICHT, GESUNDHEITSWESEN,
-                                        HANDEL, HANDWERK, HOTEL_GASTRONOMIE, LANDWIRTSCHAFT, OEFFENTLICHER_DIENST,
-                                        PRODUKTION_INDUSTRIE, VERKEHR</p>
+                                        DIENSTLEISTUNGEN_SONSTIGE, EDV_BERATUNG, ENERGIE, ERZIEHUNG_UNTERRICHT,
+                                        GESUNDHEITSWESEN, HANDEL, HANDWERK, HOTEL_GASTRONOMIE, LANDWIRTSCHAFT,
+                                        OEFFENTLICHER_DIENST, PRODUKTION_INDUSTRIE, VERKEHR</p>
                                 </div>
                                 <div class="paragraph">
                                     <p>Für Ausprägung MHB erlaubte Werte: VERARBEITENDES_GEWERBE, BAU, HANDEL,
@@ -12642,11 +12672,12 @@
                                 </div>
                                 <div class="paragraph">
                                     <p>Für Ausprägung S_RATING erlaubte Werte: BAUGEWERBE, DIENSTLEISTUNGEN,
-                                        ENERGIE_UND_WASSERVERSORGUNG_BERGBAU, GEBIETSKOERPERSCHAFTEN_UND_SOZIALVERSICHERUNGEN,
-                                        GESUNDHEITSWESEN, HANDEL, HOTEL_UND_GASTRONOMIE, KREDITINSTITUTE,
-                                        LAND_UND_FORSTWIRTSCHAFT_FISCHEREI, OEFFENTLICHER_DIENST,
-                                        ORGANISATIONEN_OHNE_ERWERBSZWECK_PRIVATE_HAUSHALTE, VERARBEITENDES_GEWERBE,
-                                        VERKEHR_UND_NACHRICHTENUEBERMITTLUNG, VERSICHERUNGEN, SONSTIGE</p>
+                                        ENERGIE_UND_WASSERVERSORGUNG_BERGBAU,
+                                        GEBIETSKOERPERSCHAFTEN_UND_SOZIALVERSICHERUNGEN, GESUNDHEITSWESEN, HANDEL,
+                                        HOTEL_UND_GASTRONOMIE, KREDITINSTITUTE, LAND_UND_FORSTWIRTSCHAFT_FISCHEREI,
+                                        OEFFENTLICHER_DIENST, ORGANISATIONEN_OHNE_ERWERBSZWECK_PRIVATE_HAUSHALTE,
+                                        VERARBEITENDES_GEWERBE, VERKEHR_UND_NACHRICHTENUEBERMITTLUNG, VERSICHERUNGEN,
+                                        SONSTIGE</p>
                                 </div>
                             </div>
                         </td>
@@ -12826,8 +12857,9 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>enum (ANNUITAETEN_DARLEHEN, FORWARD_DARLEHEN, KFW_DARLEHEN, REGIONAL_FOERDER_DARLEHEN,
-                                        PRIVAT_DARLEHEN, ZWISCHEN_FINANZIERUNG, VARIABLES_DARLEHEN)</p>
+                                    <p>enum (ANNUITAETEN_DARLEHEN, FORWARD_DARLEHEN, KFW_DARLEHEN,
+                                        REGIONAL_FOERDER_DARLEHEN, PRIVAT_DARLEHEN, ZWISCHEN_FINANZIERUNG,
+                                        VARIABLES_DARLEHEN)</p>
                                 </div>
                             </div>
                         </td>
@@ -12980,9 +13012,9 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>nur bei darlehensTyp==KFW_DARLEHEN. Mögliche Werte: STANDARD_40_PLUS, STANDARD_40,
-                                        STANDARD_55,STANDARD_70. Nur bei KfW-Programm 153 relevant. Bei neuen
-                                        Energieeffizienzstandards können auch weitere Werte zulässig werden.</p>
+                                    <p>nur bei darlehensTyp==KFW_DARLEHEN. Mögliche Werte: STANDARD_40_PLUS,
+                                        STANDARD_40, STANDARD_55,STANDARD_70. Nur bei KfW-Programm 153 relevant. Bei
+                                        neuen Energieeffizienzstandards können auch weitere Werte zulässig werden.</p>
                                 </div>
                             </div>
                         </td>
@@ -13007,8 +13039,9 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>nur bei darlehensTyp==KFW_DARLEHEN. Mögliche Werte: PROGRAMM_124, PROGRAMM_141,
-                                        PROGRAMM_151, PROGRAMM_152, PROGRAMM_153, PROGRAMM_155, PROGRAMM_159, PROGRAMM_167. Bei
-                                        neu aufgelegten KfW-Programmen können auch weitere Werte zulässig werden.</p>
+                                        PROGRAMM_151, PROGRAMM_152, PROGRAMM_153, PROGRAMM_155, PROGRAMM_159,
+                                        PROGRAMM_167. Bei neu aufgelegten KfW-Programmen können auch weitere Werte
+                                        zulässig werden.</p>
                                 </div>
                             </div>
                         </td>
@@ -13068,6 +13101,31 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
+                                    <p><strong>konditionsAnpassungsDelta</strong><br>
+                                        <em>optional</em></p>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="tableblock halign-left valign-middle">
+                            <div class="content">
+                                <div class="paragraph">
+                                    <p>Wenn die Kondition manuell angepasst wurde: Delta in Prozentpunkten, um das die
+                                        Kondition angepasst wurde.</p>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="tableblock halign-left valign-middle">
+                            <div class="content">
+                                <div class="paragraph">
+                                    <p>number</p>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-middle">
+                            <div class="content">
+                                <div class="paragraph">
                                     <p><strong>laufZeitInJahren</strong><br>
                                         <em>optional</em></p>
                                 </div>
@@ -13076,7 +13134,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>nur bei darlehensTyp==KFW_DARLEHEN</p>
+                                    <p>nur bei darlehensTyp==KFW_DARLEHEN oder
+                                        darlehensTyp==REGIONAL_FOERDER_DARLEHEN</p>
                                 </div>
                             </div>
                         </td>
@@ -13213,7 +13272,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>nur bei darlehensTyp==KFW_DARLEHEN</p>
+                                    <p>nur bei darlehensTyp==KFW_DARLEHEN oder
+                                        darlehensTyp==REGIONAL_FOERDER_DARLEHEN</p>
                                 </div>
                             </div>
                         </td>
@@ -13238,9 +13298,10 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>nur bei darlehensTyp==REGIONAL_FOERDER_DARLEHEN. Mögliche Werte:
-                                        L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, L_BANK_WOHNEN_MIT_ZUKUNFT. Bei neu
-                                        aufgelegten Programmen bzw. Aufnahme weiterer regionaler Förderbanken in die Plattform
-                                        können weitere Werte zulässig werden.</p>
+                                        L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, L_BANK_WOHNEN_MIT_ZUKUNFT,
+                                        NRW_BANK_WOHNEIGENTUM. Bei neu aufgelegten Programmen bzw. Aufnahme weiterer
+                                        regionaler Förderbanken in die Plattform können weitere Werte zulässig
+                                        werden.</p>
                                 </div>
                             </div>
                         </td>
@@ -13313,7 +13374,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>nur bei darlehensTyp==KFW_DARLEHEN</p>
+                                    <p>nur bei darlehensTyp==KFW_DARLEHEN oder
+                                        darlehensTyp==REGIONAL_FOERDER_DARLEHEN</p>
                                 </div>
                             </div>
                         </td>
@@ -13386,9 +13448,9 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Die Zinszahlung beginnt zum Abruf des Darlehensbetrages, spätestens jedoch nach Ablauf der
-                                        zinsfreien Zeit. 'zinsZahlungsBeginnAm' liefert das Datum des spätensten
-                                        Zinszahlungsbeginn.</p>
+                                    <p>Die Zinszahlung beginnt zum Abruf des Darlehensbetrages, spätestens jedoch nach
+                                        Ablauf der zinsfreien Zeit. 'zinsZahlungsBeginnAm' liefert das Datum des
+                                        spätensten Zinszahlungsbeginn.</p>
                                 </div>
                             </div>
                         </td>
@@ -13524,8 +13586,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Mediatype des Dokuments, siehe &lt;a
-                                        href="http://tools.ietf.org/html/rfc7231#section-3.1.1.1"&gt;HTTP 1.1: Semantics and
-                                        Content, section 3.1.1.1&lt;/a&gt;</p>
+                                        href="http://tools.ietf.org/html/rfc7231#section-3.1.1.1"&gt;HTTP 1.1: Semantics
+                                        and Content, section 3.1.1.1&lt;/a&gt;</p>
                                 </div>
                             </div>
                         </td>
@@ -14344,8 +14406,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>'null' wenn nicht 'Neubau', anderenfalls: true -&gt; bereits bezahlt, false - noch nicht
-                                        bezahlt</p>
+                                    <p>'null' wenn nicht 'Neubau', anderenfalls: true -&gt; bereits bezahlt, false -
+                                        noch nicht bezahlt</p>
                                 </div>
                             </div>
                         </td>
@@ -14689,8 +14751,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -14814,8 +14876,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -14839,8 +14901,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -14884,8 +14946,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -14909,8 +14971,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -14959,8 +15021,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -14984,10 +15046,10 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.. Erlaubte Werte sind: GEHOBEN,MITTEL,EINFACH. Neue
-                                        Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten
-                                        umgehen können.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.. Erlaubte Werte
+                                        sind: GEHOBEN,MITTEL,EINFACH. Neue Ausprägungen können kurzfristig hinzukommen.
+                                        Der Client muss daher mit unbekannten Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -15180,9 +15242,10 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Angaben zur Ausstattung für alle verschiedene Produktanbieter und für die für die
-                                        automatische Objektbewertungs-Schnittstelle (VDP), aber nicht für ING. Erlaubte Werte
-                                        sind: EINFACH,MITTEL,GEHOBEN,STARK_GEHOBEN. Neue Ausprägungen können kurzfristig
-                                        hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.</p>
+                                        automatische Objektbewertungs-Schnittstelle (VDP), aber nicht für ING. Erlaubte
+                                        Werte sind: EINFACH,MITTEL,GEHOBEN,STARK_GEHOBEN. Neue Ausprägungen können
+                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen
+                                        können.</p>
                                 </div>
                             </div>
                         </td>
@@ -15231,9 +15294,10 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Erlaubte Werte sind: FACHWERK_MIT_STROH_LEHM,FACHWERK_MIT_ZIEGELN,GLAS_STAHL,HOLZ,MASSIV.
-                                        Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten
-                                        Werten umgehen können.</p>
+                                    <p>Erlaubte Werte sind:
+                                        FACHWERK_MIT_STROH_LEHM,FACHWERK_MIT_ZIEGELN,GLAS_STAHL,HOLZ,MASSIV. Neue
+                                        Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
+                                        unbekannten Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -15282,8 +15346,9 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Nur bei ObjektArt == HAUS. Erlaubte Werte sind:
-                                        FLACHDACH,NICHT_AUSGEBAUT,TEILWEISE_AUSGEBAUT,VOLL_AUSGEBAUT. Neue Ausprägungen können
-                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.</p>
+                                        FLACHDACH,NICHT_AUSGEBAUT,TEILWEISE_AUSGEBAUT,VOLL_AUSGEBAUT. Neue Ausprägungen
+                                        können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten
+                                        umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -15420,8 +15485,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Angabe in Kubikmetern. Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
-                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Angabe in Kubikmetern. Diese Angabe ist produktanbieterspezifisch, sie wird nicht
+                                        von allen Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -15469,8 +15534,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -15520,7 +15585,8 @@
                                 <div class="paragraph">
                                     <p>Nur bei ObjektArt == HAUS. Erlaubte Werte sind:
                                         NICHT_UNTERKELLERT,TEILWEISE_UNTERKELLERT,UNTERKELLERT. Neue Ausprägungen können
-                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.</p>
+                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen
+                                        können.</p>
                                 </div>
                             </div>
                         </td>
@@ -15564,8 +15630,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Angaben zum Zustand der Immobilie für die automatische Objektbewertungs-Schnittstelle
-                                        (VDP)</p>
+                                    <p>Angaben zum Zustand der Immobilie für die automatische
+                                        Objektbewertungs-Schnittstelle (VDP)</p>
                                 </div>
                             </div>
                         </td>
@@ -15771,8 +15837,9 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Belastungen und Beschränkungen in der Nutzbarkeit des Grundstücks. Leitungsrechte,
-                                        Verzichte auf Abstandsflächen, Wegerechte, Insolvenzvermerke.</p>
+                                    <p>Belastungen und Beschränkungen in der Nutzbarkeit des Grundstücks.
+                                        Leitungsrechte, Verzichte auf Abstandsflächen, Wegerechte,
+                                        Insolvenzvermerke.</p>
                                 </div>
                             </div>
                         </td>
@@ -15888,8 +15955,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -15913,8 +15980,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -15978,8 +16045,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt.</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt.</p>
                                 </div>
                             </div>
                         </td>
@@ -16023,8 +16090,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei
-                                        der Angebotsermittlung berücksichtigt. (DSL Bank)</p>
+                                    <p>Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen
+                                        Produktanbietern bei der Angebotsermittlung berücksichtigt. (DSL Bank)</p>
                                 </div>
                             </div>
                         </td>
@@ -16130,7 +16197,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>&lt; <a href="#_bestehenderbausparvertrag">BestehenderBausparvertrag</a> &gt; array</p>
+                                    <p>&lt; <a href="#_bestehenderbausparvertrag">BestehenderBausparvertrag</a> &gt;
+                                        array</p>
                                 </div>
                             </div>
                         </td>
@@ -16170,8 +16238,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>&lt; <a href="#_einkuenfteausnebentaetigkeit">EinkuenfteAusNebentaetigkeit</a> &gt; array
-                                    </p>
+                                    <p>&lt; <a href="#_einkuenfteausnebentaetigkeit">EinkuenfteAusNebentaetigkeit</a>
+                                        &gt; array</p>
                                 </div>
                             </div>
                         </td>
@@ -17191,8 +17259,8 @@
                                 <div class="paragraph">
                                     <p>Mögliche Werte sind:
                                         AUSZAHLUNGS_VORAUSSETZUNG,MACHBAR,MACHBARKEITS_HINWEIS,ANPASSUNG_KUNDENWUNSCH,ANPASSUNG_VERTRIEBSWUNSCH,UNBERUECKSICHTIGTE_ANGABE,KONDITIONEN_UNTER_VORBEHALT_VOLLSTAENDIGER_DATEN,KONDITIONEN_UNTER_VORBEHALT_EXTERNER_SCHNITTSTELLEN,MACHBARKEIT_UNTER_VORBEHALT_VOLLSTAENDIGER_DATEN,MACHBARKEIT_UNTER_VORBEHALT_EXTERNER_SCHNITTSTELLEN,MACHBAR_UNTER_VORBEHALT_PRODUZENT,NICHT_MACHBAR,NICHT_ANBIETBAR.
-                                        Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten
-                                        Werten umgehen können.</p>
+                                        Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
+                                        unbekannten Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -17449,8 +17517,9 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Erlaubte Werte sind: UEBERWIEGEND,UMFASSEND,MITTEL,EINFACH. Neue Ausprägungen können
-                                        kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.</p>
+                                    <p>Erlaubte Werte sind: UEBERWIEGEND,UMFASSEND,MITTEL,EINFACH. Neue Ausprägungen
+                                        können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten
+                                        umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -17474,17 +17543,17 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Erlaubte Werte sind: KERNSANIERUNG, DACHERNEUERUNG, FENSTER, ROHRLEITUNGEN, HEIZUNG,
-                                        WAERMEDAEMMUNG, BAEDER, INNENAUSBAU, RAUMAUFTEILUNG. Der Client muss daher mit unbekannten
-                                        Werten umgehen können.</p>
+                                    <p>Erlaubte Werte sind: KERNSANIERUNG, DACHERNEUERUNG, FENSTER, ROHRLEITUNGEN,
+                                        HEIZUNG, WAERMEDAEMMUNG, BAEDER, INNENAUSBAU, RAUMAUFTEILUNG. Der Client muss
+                                        daher mit unbekannten Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>enum (KERNSANIERUNG, DACHERNEUERUNG, FENSTER, ROHRLEITUNGEN, HEIZUNG, WAERMEDAEMMUNG,
-                                        BAEDER, INNENAUSBAU, RAUMAUFTEILUNG)</p>
+                                    <p>enum (KERNSANIERUNG, DACHERNEUERUNG, FENSTER, ROHRLEITUNGEN, HEIZUNG,
+                                        WAERMEDAEMMUNG, BAEDER, INNENAUSBAU, RAUMAUFTEILUNG)</p>
                                 </div>
                             </div>
                         </td>
@@ -17520,8 +17589,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>erlaubt sind GERING,MITTEL,HOCH. Neue Ausprägungen können kurzfristig hinzukommen. Der
-                                        Client muss daher mit unbekannten Werten umgehen können.</p>
+                                    <p>erlaubt sind GERING,MITTEL,HOCH. Neue Ausprägungen können kurzfristig
+                                        hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -17609,8 +17678,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Der Name des externen Darlehensgebers (Firmierung). Es gibt keine entsprechende Beziehung
-                                        zu einem Partner auf der Europace-Plattform.</p>
+                                    <p>Der Name des externen Darlehensgebers (Firmierung). Es gibt keine entsprechende
+                                        Beziehung zu einem Partner auf der Europace-Plattform.</p>
                                 </div>
                             </div>
                         </td>
@@ -17695,9 +17764,9 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>Erlaubte Werte sind:
-                                        ARBEITGEBERDARLEHEN,BAUSPARDARLEHEN,OEFFENTLICHES_DARLEHEN,RATENKREDIT. Neue Ausprägungen
-                                        können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen
-                                        können.</p>
+                                        ARBEITGEBERDARLEHEN,BAUSPARDARLEHEN,OEFFENTLICHES_DARLEHEN,RATENKREDIT. Neue
+                                        Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit
+                                        unbekannten Werten umgehen können.</p>
                                 </div>
                             </div>
                         </td>
@@ -17803,8 +17872,8 @@
             <div class="sect2">
                 <h3 id="_partner">Partner</h3>
                 <div class="paragraph">
-                    <p>Minimale Informationen zum Partner der EP2 Plattform, weitere Informationen können über die HAL-Relation
-                        abgerufen werden.</p>
+                    <p>Minimale Informationen zum Partner der EP2 Plattform, weitere Informationen können über die
+                        HAL-Relation abgerufen werden.</p>
                 </div>
                 <table class="tableblock frame-all grid-all stretch">
                     <colgroup>
@@ -18291,8 +18360,8 @@
                             <div class="content">
                                 <div class="paragraph">
                                     <p>JSON-Path im Antrag. Valide Pfade sind: '/antragsReferenz', '/status',
-                                        '/status/antragsteller', '/ansprechpartner/partnerId', '/status/produktAnbieter',
-                                        '/voraussichtlicheBearbeitung'.</p>
+                                        '/status/antragsteller', '/ansprechpartner/partnerId',
+                                        '/status/produktAnbieter', '/voraussichtlicheBearbeitung'.</p>
                                 </div>
                             </div>
                         </td>
@@ -18316,7 +18385,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Zu setzender oder auszutauschender Wert. Erlaubt sind string, number oder JSON object<br>
+                                    <p>Zu setzender oder auszutauschender Wert. Erlaubt sind string, number oder JSON
+                                        object<br>
                                         <strong>Beispiel</strong> : <code>"\"WER123\", 1234, {\"antragsteller\":
                                             \"BEANTRAGT\"}"</code></p>
                                 </div>
@@ -19072,8 +19142,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Die Ermittlung des Schufa-Scores verzögert sich, wenn sich die Anfrage bei der Schufa in
-                                        manueller Nachbehandlung befindet.</p>
+                                    <p>Die Ermittlung des Schufa-Scores verzögert sich, wenn sich die Anfrage bei der
+                                        Schufa in manueller Nachbehandlung befindet.</p>
                                 </div>
                             </div>
                         </td>
@@ -19754,8 +19824,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>Id des Tilgungsersatzproduktes, das in den Vermögenswerten des Haushalts oder in den
-                                        Bausparangeboten des Angebotes zu finden ist.</p>
+                                    <p>Id des Tilgungsersatzproduktes, das in den Vermögenswerten des Haushalts oder in
+                                        den Bausparangeboten des Angebotes zu finden ist.</p>
                                 </div>
                             </div>
                         </td>
@@ -20326,7 +20396,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>&lt; <a href="#_vermoegenverbindlichkeit">VermoegenVerbindlichkeit</a> &gt; array</p>
+                                    <p>&lt; <a href="#_vermoegenverbindlichkeit">VermoegenVerbindlichkeit</a> &gt; array
+                                    </p>
                                 </div>
                             </div>
                         </td>
@@ -20496,8 +20567,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>&lt; <a href="#_nachrangigesexternesdarlehen">NachrangigesExternesDarlehen</a> &gt; array
-                                    </p>
+                                    <p>&lt; <a href="#_nachrangigesexternesdarlehen">NachrangigesExternesDarlehen</a>
+                                        &gt; array</p>
                                 </div>
                             </div>
                         </td>
@@ -20514,8 +20585,8 @@
                         <td class="tableblock halign-left valign-middle">
                             <div class="content">
                                 <div class="paragraph">
-                                    <p>enum (ANSCHLUSSFINANZIERUNG, KAUF, KAUF_NEUBAU_VOM_BAUTRAEGER, MODERNISIERUNG_UMBAU_ANBAU,
-                                        NEUBAU, KAPITALBESCHAFFUNG)</p>
+                                    <p>enum (ANSCHLUSSFINANZIERUNG, KAUF, KAUF_NEUBAU_VOM_BAUTRAEGER,
+                                        MODERNISIERUNG_UMBAU_ANBAU, NEUBAU, KAPITALBESCHAFFUNG)</p>
                                 </div>
                             </div>
                         </td>
@@ -21015,7 +21086,7 @@
 </div>
 <div id="footer">
     <div id="footer-text">
-        Last updated 2020-09-23 22:17:45 +0200
+        Last updated 2020-11-09 17:52:13 +0100
     </div>
 </div>
 </body>

--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Kontext des Produktanbieters eingenommen.",
-    "version": "2.28",
+    "version": "2.29",
     "title": "Anträge API",
     "contact": {
       "name": "Europace AG",
@@ -984,7 +984,7 @@
       "tokenUrl": "https://api.europace.de/auth/access-token",
       "flow": "application",
       "scopes": {
-        "baufinanzierung:antrag:lesen": "Lesen eines Antrags oder mehrerer Anträge",
+        "baufinanzierung:antrag:lesen": "Auslesen von Anträgen",
         "baufinanzierung:antrag:schreiben": "Ändern von Daten eines Antrags (bspw. Antragsstatus, Kreditsachbearbeiter)"
       }
     }
@@ -2337,10 +2337,14 @@
           "type": "string",
           "description": "Begründung, wenn die Kondition angepasst wurde"
         },
+        "konditionsAnpassungsDelta": {
+          "type": "number",
+          "description": "Wenn die Kondition manuell angepasst wurde: Delta in Prozentpunkten, um das die Kondition angepasst wurde."
+        },
         "laufZeitInJahren": {
           "type": "integer",
           "format": "int32",
-          "description": "nur bei darlehensTyp==KFW_DARLEHEN"
+          "description": "nur bei darlehensTyp==KFW_DARLEHEN oder darlehensTyp==REGIONAL_FOERDER_DARLEHEN"
         },
         "laufzeitInMonaten": {
           "type": "integer",
@@ -2365,11 +2369,11 @@
         },
         "rateMonatlichInDerTilgungsfreienAnlaufzeit": {
           "type": "number",
-          "description": "nur bei darlehensTyp==KFW_DARLEHEN"
+          "description": "nur bei darlehensTyp==KFW_DARLEHEN oder darlehensTyp==REGIONAL_FOERDER_DARLEHEN"
         },
         "regionalFoerderbankProgramm": {
           "type": "string",
-          "description": "nur bei darlehensTyp==REGIONAL_FOERDER_DARLEHEN. Mögliche Werte: L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, L_BANK_WOHNEN_MIT_ZUKUNFT. Bei neu aufgelegten Programmen bzw. Aufnahme weiterer regionaler Förderbanken in die Plattform können weitere Werte zulässig werden."
+          "description": "nur bei darlehensTyp==REGIONAL_FOERDER_DARLEHEN. Mögliche Werte: L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, L_BANK_WOHNEN_MIT_ZUKUNFT, NRW_BANK_WOHNEIGENTUM. Bei neu aufgelegten Programmen bzw. Aufnahme weiterer regionaler Förderbanken in die Plattform können weitere Werte zulässig werden."
         },
         "sollZins": {
           "type": "number",
@@ -2383,7 +2387,7 @@
         "tilgungsFreieAnlaufJahre": {
           "type": "integer",
           "format": "int32",
-          "description": "nur bei darlehensTyp==KFW_DARLEHEN"
+          "description": "nur bei darlehensTyp==KFW_DARLEHEN oder darlehensTyp==REGIONAL_FOERDER_DARLEHEN"
         },
         "verwendungsZweck": {
           "type": "string",

--- a/swagger.json
+++ b/swagger.json
@@ -2340,6 +2340,7 @@
         },
         "konditionsAnpassungsDelta": {
           "type": "number",
+          "example": -0.25,
           "description": "Wenn die Kondition manuell angepasst wurde: Delta in Prozentpunkten, um das die Kondition angepasst wurde (Differenz aus angepasster und ursprünglich berechneter Kondition, z.B. angepasst 1,25% - ursprünglich 1,50% = Delta von -0,25%)."
         },
         "laufZeitInJahren": {

--- a/swagger.json
+++ b/swagger.json
@@ -2270,7 +2270,7 @@
         "auszahlungsDatum": {
           "type": "string",
           "format": "date",
-          "description": "nur bei darlehensTyp IN [FORWARD_DARLEHEN,ANNUITAETEN_DARLEHEN]"
+          "description": "Datum, an dem das Darlehen dem Kunden ausgezahlt werden soll. Entweder berechnet oder vom Kunden angegeben."
         },
         "auszahlungsKurs": {
           "type": "number"

--- a/swagger.json
+++ b/swagger.json
@@ -2331,7 +2331,8 @@
           "description": "nur bei darlehensTyp==KFW_DARLEHEN. Mögliche Werte: PROGRAMM_124, PROGRAMM_141, PROGRAMM_151, PROGRAMM_152, PROGRAMM_153, PROGRAMM_155, PROGRAMM_159, PROGRAMM_167. Bei neu aufgelegten KfW-Programmen können auch weitere Werte zulässig werden."
         },
         "konditionWurdeManuellAngepasst": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "true, wenn die Kondition manuell durch den Berater angepasst wurde (d.h. entweder Soll- oder Effektivzins des Darlehens, je nachdem welche Anpassung durch den Produktanbieter erlaubt ist)."
         },
         "konditionsAnpassungsBegruendung": {
           "type": "string",
@@ -2339,7 +2340,7 @@
         },
         "konditionsAnpassungsDelta": {
           "type": "number",
-          "description": "Wenn die Kondition manuell angepasst wurde: Delta in Prozentpunkten, um das die Kondition angepasst wurde."
+          "description": "Wenn die Kondition manuell angepasst wurde: Delta in Prozentpunkten, um das die Kondition angepasst wurde (Differenz aus angepasster und ursprünglich berechneter Kondition, z.B. angepasst 1,25% - ursprünglich 1,50% = Delta von -0,25%)."
         },
         "laufZeitInJahren": {
           "type": "integer",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1649,6 +1649,7 @@ definitions:
         description: Begründung, wenn die Kondition angepasst wurde
       konditionsAnpassungsDelta:
         type: number
+        example: -0.25
         description: 'Wenn die Kondition manuell angepasst wurde: Delta in Prozentpunkten, um das die Kondition angepasst wurde (Differenz aus angepasster und ursprünglich berechneter Kondition, z.B. angepasst 1,25% - ursprünglich 1,50% = Delta von -0,25%).'
       laufZeitInJahren:
         type: integer

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1596,7 +1596,7 @@ definitions:
       auszahlungsDatum:
         type: string
         format: date
-        description: nur bei darlehensTyp IN [FORWARD_DARLEHEN,ANNUITAETEN_DARLEHEN]
+        description: Datum, an dem das Darlehen dem Kunden ausgezahlt werden soll. Entweder berechnet oder vom Kunden angegeben.
       auszahlungsKurs:
         type: number
       bausteinId:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2,7 +2,7 @@
 swagger: "2.0"
 info:
   description: Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Kontext des Produktanbieters eingenommen.
-  version: "2.28"
+  version: "2.29"
   title: Anträge API
   contact:
     name: Europace AG
@@ -667,7 +667,7 @@ securityDefinitions:
     tokenUrl: https://api.europace.de/auth/access-token
     flow: application
     scopes:
-      baufinanzierung:antrag:lesen: Lesen eines Antrags oder mehrerer Anträge
+      baufinanzierung:antrag:lesen: Auslesen von Anträgen
       baufinanzierung:antrag:schreiben: Ändern von Daten eines Antrags (bspw. Antragsstatus, Kreditsachbearbeiter)
 definitions:
   Absicherung:
@@ -1648,11 +1648,11 @@ definitions:
         description: Begründung, wenn die Kondition angepasst wurde
       konditionsAnpassungsDelta:
         type: number
-        description: 'Wenn die Kondition manuell angepasst wurde: Delta in Prozentpunkten, um das die Kondition angepasst wurde (Differenz aus neuer zu ursprünglicher Kondition)'
+        description: 'Wenn die Kondition manuell angepasst wurde: Delta in Prozentpunkten, um das die Kondition angepasst wurde.'
       laufZeitInJahren:
         type: integer
         format: int32
-        description: nur bei darlehensTyp==KFW_DARLEHEN
+        description: nur bei darlehensTyp==KFW_DARLEHEN oder darlehensTyp==REGIONAL_FOERDER_DARLEHEN
       laufzeitInMonaten:
         type: integer
         format: int32
@@ -1671,10 +1671,10 @@ definitions:
         description: Die monatliche Rate in Euro
       rateMonatlichInDerTilgungsfreienAnlaufzeit:
         type: number
-        description: nur bei darlehensTyp==KFW_DARLEHEN
+        description: nur bei darlehensTyp==KFW_DARLEHEN oder darlehensTyp==REGIONAL_FOERDER_DARLEHEN
       regionalFoerderbankProgramm:
         type: string
-        description: 'nur bei darlehensTyp==REGIONAL_FOERDER_DARLEHEN. Mögliche Werte: L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, L_BANK_WOHNEN_MIT_ZUKUNFT. Bei neu aufgelegten Programmen bzw. Aufnahme weiterer regionaler Förderbanken in die Plattform können weitere Werte zulässig werden.'
+        description: 'nur bei darlehensTyp==REGIONAL_FOERDER_DARLEHEN. Mögliche Werte: L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, L_BANK_WOHNEN_MIT_ZUKUNFT, NRW_BANK_WOHNEIGENTUM. Bei neu aufgelegten Programmen bzw. Aufnahme weiterer regionaler Förderbanken in die Plattform können weitere Werte zulässig werden.'
       sollZins:
         type: number
         example: 2.05
@@ -1685,7 +1685,7 @@ definitions:
       tilgungsFreieAnlaufJahre:
         type: integer
         format: int32
-        description: nur bei darlehensTyp==KFW_DARLEHEN
+        description: nur bei darlehensTyp==KFW_DARLEHEN oder darlehensTyp==REGIONAL_FOERDER_DARLEHEN
       verwendungsZweck:
         type: string
         description: nur bei darlehensTyp==ZWISCHEN_FINANZIERUNG

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1643,12 +1643,13 @@ definitions:
         description: 'nur bei darlehensTyp==KFW_DARLEHEN. Mögliche Werte: PROGRAMM_124, PROGRAMM_141, PROGRAMM_151, PROGRAMM_152, PROGRAMM_153, PROGRAMM_155, PROGRAMM_159, PROGRAMM_167. Bei neu aufgelegten KfW-Programmen können auch weitere Werte zulässig werden.'
       konditionWurdeManuellAngepasst:
         type: boolean
+        description: true, wenn die Kondition manuell durch den Berater angepasst wurde (d.h. entweder Soll- oder Effektivzins des Darlehens, je nachdem welche Anpassung durch den Produktanbieter erlaubt ist).
       konditionsAnpassungsBegruendung:
         type: string
         description: Begründung, wenn die Kondition angepasst wurde
       konditionsAnpassungsDelta:
         type: number
-        description: 'Wenn die Kondition manuell angepasst wurde: Delta in Prozentpunkten, um das die Kondition angepasst wurde.'
+        description: 'Wenn die Kondition manuell angepasst wurde: Delta in Prozentpunkten, um das die Kondition angepasst wurde (Differenz aus angepasster und ursprünglich berechneter Kondition, z.B. angepasst 1,25% - ursprünglich 1,50% = Delta von -0,25%).'
       laufZeitInJahren:
         type: integer
         format: int32

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1646,6 +1646,9 @@ definitions:
       konditionsAnpassungsBegruendung:
         type: string
         description: Begründung, wenn die Kondition angepasst wurde
+      konditionsAnpassungsDelta:
+        type: number
+        description: 'Wenn die Kondition manuell angepasst wurde: Delta in Prozentpunkten, um das die Kondition angepasst wurde (Differenz aus neuer zu ursprünglicher Kondition)'
       laufZeitInJahren:
         type: integer
         format: int32


### PR DESCRIPTION
Relates to 
[BEV-670]
[EN-473]

Zu releasen nach Integration und Rollout von 
hypoport/antraege-edge-server#243
hypoport/antraege-edge-server#245

### Motivation

* Konditionsanpassungen sollen an den Darlehen des Antrags leichter nachvollzogen werden können.
  Da einige Produktanbieter (z.B. OLB) explizite Spannbreiten für zulässige Konditionsanpassungen angeben,
  bzw. als Regel haben (z.B. von -0,20% bis +0,20%), ist es sinnvoll, das tatsächliche Delta mit auszugeben,
  so dass die Einhaltung der zulässigen Anpassungsspannbreite leicht nachvollzogen werden kann.

### Changes

* Darlehen wird erweitert um ein Number-wertiges Attribut `konditionsAnpassungsDelta`,
  das die Prozentpunkte des Anpassungs-Deltas enthält, d.h. die Differenz aus
  jetziger, angepasster Kondition, und der ursprünglichen Kondition.
  Z.b. angepasste Kondition 1,45%, ursprüngliche Konditionn 1,50% -> Anpassungsdelta = -0,05%
* Am Darlehen wird das Attribut AuszahlungsDatum bei allen Darlehensarten gefüllt
* Weitere Änderungen in der API-Spec ergeben sich aus Anpassungen im Antraege-Edge-Server, die bislang noch nicht released wurden

[BEV-670]: https://europace.atlassian.net/browse/BEV-670

[EN-473]: https://europace.atlassian.net/browse/EN-473