### PR TITLE
Release 2.32 - Neue Restschuldfelder

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -590,7 +590,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="sect2">
 <h3 id="_aktuelle_version">Aktuelle Version</h3>
 <div class="paragraph">
-<p><em>Version</em> : 2.31</p>
+<p><em>Version</em> : 2.32</p>
 </div>
 </div>
 <div class="sect2">
@@ -3909,7 +3909,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p>enum (ANNUITAETEN_DARLEHEN)</p>
+<p>enum (ANNUITAETEN_DARLEHEN, FORWARD_DARLEHEN, KFW_DARLEHEN, PRIVAT_DARLEHEN, REGIONAL_FOERDER_DARLEHEN, VARIABLES_DARLEHEN, ZWISCHEN_FINANZIERUNG)</p>
 </div></div></td>
 </tr>
 <tr>
@@ -3959,7 +3959,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p><strong>vertriebsProvisionGesamtAbsolut</strong><br>
 <em>verpflichtend</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>number</p>
 </div></div></td>
@@ -6395,7 +6397,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p><strong>abzuloesendeRestschuld</strong><br>
 <em>optional</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Deprecated.</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>number</p>
 </div></div></td>
@@ -6406,7 +6410,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <em>optional</em></p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p>nur wenn wirdAbgeloest==true</p>
+<p>Deprecated. nur wenn wirdAbgeloest==true</p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>number</p>
@@ -6534,6 +6538,30 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </tr>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>restschuldAktuell</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Die aktuelle Restschuld bezüglich des Darlehens.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>number</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>restschuldZumAbloeseTermin</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Die kalkulatorische Restschuld zum Ende der Zinsbindung.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>number</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>sollZins</strong><br>
 <em>optional</em></p>
 </div></div></td>
@@ -6552,6 +6580,18 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>number</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>wirdAbgeloest</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>true, wenn Darlehen abgelöst wird, ansonsten false</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>boolean</p>
 </div></div></td>
 </tr>
 <tr>
@@ -6588,7 +6628,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p><strong>abzuloesendeRestschuld</strong><br>
 <em>optional</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Deprecated.</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>number</p>
 </div></div></td>
@@ -6599,7 +6641,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <em>optional</em></p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p>nur wenn wirdAbgeloest==true</p>
+<p>Deprecated. nur wenn wirdAbgeloest==true</p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>number</p>
@@ -6727,6 +6769,30 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </tr>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>restschuldAktuell</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Die aktuelle Restschuld bezüglich des Darlehens.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>number</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>restschuldZumAbloeseTermin</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Die kalkulatorische Restschuld zum Ende der Zinsbindung.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>number</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>sollZins</strong><br>
 <em>optional</em></p>
 </div></div></td>
@@ -6757,6 +6823,18 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>enum (ABLOESEN, TRITT_IM_RANG_ZURUECK, TRITT_NICHT_IM_RANG_ZURUECK)</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>wirdAbgeloest</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>true, wenn Darlehen abgelöst wird, ansonsten false</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>boolean</p>
 </div></div></td>
 </tr>
 <tr>
@@ -8311,7 +8389,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p>enum (FORWARD_DARLEHEN)</p>
+<p>enum (ANNUITAETEN_DARLEHEN, FORWARD_DARLEHEN, KFW_DARLEHEN, PRIVAT_DARLEHEN, REGIONAL_FOERDER_DARLEHEN, VARIABLES_DARLEHEN, ZWISCHEN_FINANZIERUNG)</p>
 </div></div></td>
 </tr>
 <tr>
@@ -8361,7 +8439,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p><strong>vertriebsProvisionGesamtAbsolut</strong><br>
 <em>verpflichtend</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>number</p>
 </div></div></td>
@@ -8806,7 +8886,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>darlehensTyp</strong><br>
-<em>optional</em></p>
+<em>verpflichtend</em></p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
@@ -8860,7 +8940,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p><strong>vertriebsProvisionGesamtAbsolut</strong><br>
 <em>verpflichtend</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>number</p>
 </div></div></td>
@@ -9414,7 +9496,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p>enum (KFW_DARLEHEN)</p>
+<p>enum (ANNUITAETEN_DARLEHEN, FORWARD_DARLEHEN, KFW_DARLEHEN, PRIVAT_DARLEHEN, REGIONAL_FOERDER_DARLEHEN, VARIABLES_DARLEHEN, ZWISCHEN_FINANZIERUNG)</p>
 </div></div></td>
 </tr>
 <tr>
@@ -9464,7 +9546,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p><strong>vertriebsProvisionGesamtAbsolut</strong><br>
 <em>verpflichtend</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>number</p>
 </div></div></td>
@@ -10692,7 +10776,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p>enum (PRIVAT_DARLEHEN)</p>
+<p>enum (ANNUITAETEN_DARLEHEN, FORWARD_DARLEHEN, KFW_DARLEHEN, PRIVAT_DARLEHEN, REGIONAL_FOERDER_DARLEHEN, VARIABLES_DARLEHEN, ZWISCHEN_FINANZIERUNG)</p>
 </div></div></td>
 </tr>
 <tr>
@@ -10742,7 +10826,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p><strong>vertriebsProvisionGesamtAbsolut</strong><br>
 <em>verpflichtend</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>number</p>
 </div></div></td>
@@ -11169,7 +11255,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p>enum (REGIONAL_FOERDER_DARLEHEN)</p>
+<p>enum (ANNUITAETEN_DARLEHEN, FORWARD_DARLEHEN, KFW_DARLEHEN, PRIVAT_DARLEHEN, REGIONAL_FOERDER_DARLEHEN, VARIABLES_DARLEHEN, ZWISCHEN_FINANZIERUNG)</p>
 </div></div></td>
 </tr>
 <tr>
@@ -11219,7 +11305,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p><strong>vertriebsProvisionGesamtAbsolut</strong><br>
 <em>verpflichtend</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>number</p>
 </div></div></td>
@@ -11927,7 +12015,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p>enum (VARIABLES_DARLEHEN)</p>
+<p>enum (ANNUITAETEN_DARLEHEN, FORWARD_DARLEHEN, KFW_DARLEHEN, PRIVAT_DARLEHEN, REGIONAL_FOERDER_DARLEHEN, VARIABLES_DARLEHEN, ZWISCHEN_FINANZIERUNG)</p>
 </div></div></td>
 </tr>
 <tr>
@@ -11977,7 +12065,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p><strong>vertriebsProvisionGesamtAbsolut</strong><br>
 <em>verpflichtend</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>number</p>
 </div></div></td>
@@ -12755,7 +12845,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-01-13 16:47:21 +0100
+Last updated 2021-02-09 09:24:27 +0100
 </div>
 </div>
 </body>

--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Kontext des Produktanbieters eingenommen.",
-    "version": "2.31",
+    "version": "2.32",
     "title": "Anträge API",
     "contact": {
       "name": "Europace AG",
@@ -1290,7 +1290,13 @@
             "darlehensTyp": {
               "type": "string",
               "enum": [
-                "ANNUITAETEN_DARLEHEN"
+                "ANNUITAETEN_DARLEHEN",
+                "FORWARD_DARLEHEN",
+                "KFW_DARLEHEN",
+                "PRIVAT_DARLEHEN",
+                "REGIONAL_FOERDER_DARLEHEN",
+                "VARIABLES_DARLEHEN",
+                "ZWISCHEN_FINANZIERUNG"
               ]
             },
             "effektivZins": {
@@ -1319,7 +1325,8 @@
               "example": "2020-03-28"
             },
             "vertriebsProvisionGesamtAbsolut": {
-              "type": "number"
+              "type": "number",
+              "description": "Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet."
             },
             "zinsBindungInJahren": {
               "type": "integer",
@@ -2253,11 +2260,12 @@
       "type": "object",
       "properties": {
         "abzuloesendeRestschuld": {
-          "type": "number"
+          "type": "number",
+          "description": "Deprecated."
         },
         "aktuelleRestschuldWennNichtAbzuloesen": {
           "type": "number",
-          "description": "nur wenn wirdAbgeloest==true"
+          "description": "Deprecated. nur wenn wirdAbgeloest==true"
         },
         "bausteinId": {
           "type": "string"
@@ -2309,12 +2317,24 @@
         "rateMonatlich": {
           "type": "number"
         },
+        "restschuldAktuell": {
+          "type": "number",
+          "description": "Die aktuelle Restschuld bezüglich des Darlehens."
+        },
+        "restschuldZumAbloeseTermin": {
+          "type": "number",
+          "description": "Die kalkulatorische Restschuld zum Ende der Zinsbindung."
+        },
         "sollZins": {
           "type": "number"
         },
         "sondertilgungZumZinsBindungsEnde": {
           "type": "number",
           "description": "für Prolongation, d.h. technisch: Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG"
+        },
+        "wirdAbgeloest": {
+          "type": "boolean",
+          "description": "true, wenn Darlehen abgelöst wird, ansonsten false"
         },
         "zinsBindungEndetAm": {
           "type": "string",
@@ -2327,11 +2347,12 @@
       "type": "object",
       "properties": {
         "abzuloesendeRestschuld": {
-          "type": "number"
+          "type": "number",
+          "description": "Deprecated."
         },
         "aktuelleRestschuldWennNichtAbzuloesen": {
           "type": "number",
-          "description": "nur wenn wirdAbgeloest==true"
+          "description": "Deprecated. nur wenn wirdAbgeloest==true"
         },
         "bausteinId": {
           "type": "string"
@@ -2382,6 +2403,14 @@
         },
         "rateMonatlich": {
           "type": "number"
+        },
+        "restschuldAktuell": {
+          "type": "number",
+          "description": "Die aktuelle Restschuld bezüglich des Darlehens."
+        },
+        "restschuldZumAbloeseTermin": {
+          "type": "number",
+          "description": "Die kalkulatorische Restschuld zum Ende der Zinsbindung."
         },
         "sollZins": {
           "type": "number"
@@ -2398,6 +2427,10 @@
             "TRITT_IM_RANG_ZURUECK",
             "TRITT_NICHT_IM_RANG_ZURUECK"
           ]
+        },
+        "wirdAbgeloest": {
+          "type": "boolean",
+          "description": "true, wenn Darlehen abgelöst wird, ansonsten false"
         },
         "zinsBindungEndetAm": {
           "type": "string",
@@ -2992,7 +3025,13 @@
             "darlehensTyp": {
               "type": "string",
               "enum": [
-                "FORWARD_DARLEHEN"
+                "ANNUITAETEN_DARLEHEN",
+                "FORWARD_DARLEHEN",
+                "KFW_DARLEHEN",
+                "PRIVAT_DARLEHEN",
+                "REGIONAL_FOERDER_DARLEHEN",
+                "VARIABLES_DARLEHEN",
+                "ZWISCHEN_FINANZIERUNG"
               ]
             },
             "effektivZins": {
@@ -3025,7 +3064,8 @@
               "example": "2020-03-28"
             },
             "vertriebsProvisionGesamtAbsolut": {
-              "type": "number"
+              "type": "number",
+              "description": "Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet."
             },
             "zinsBindungInJahren": {
               "type": "integer",
@@ -3181,6 +3221,7 @@
       "required": [
         "anfaenglicheTilgung",
         "darlehensBetrag",
+        "darlehensTyp",
         "effektivZins",
         "rateMonatlich",
         "sollZins",
@@ -3220,7 +3261,8 @@
           "type": "number"
         },
         "vertriebsProvisionGesamtAbsolut": {
-          "type": "number"
+          "type": "number",
+          "description": "Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet."
         }
       },
       "title": "GegenangebotDarlehen"
@@ -3505,7 +3547,13 @@
             "darlehensTyp": {
               "type": "string",
               "enum": [
-                "KFW_DARLEHEN"
+                "ANNUITAETEN_DARLEHEN",
+                "FORWARD_DARLEHEN",
+                "KFW_DARLEHEN",
+                "PRIVAT_DARLEHEN",
+                "REGIONAL_FOERDER_DARLEHEN",
+                "VARIABLES_DARLEHEN",
+                "ZWISCHEN_FINANZIERUNG"
               ]
             },
             "effektivZins": {
@@ -3553,7 +3601,8 @@
               "format": "int32"
             },
             "vertriebsProvisionGesamtAbsolut": {
-              "type": "number"
+              "type": "number",
+              "description": "Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet."
             },
             "zinsBindungInJahren": {
               "type": "integer",
@@ -4008,7 +4057,13 @@
             "darlehensTyp": {
               "type": "string",
               "enum": [
-                "PRIVAT_DARLEHEN"
+                "ANNUITAETEN_DARLEHEN",
+                "FORWARD_DARLEHEN",
+                "KFW_DARLEHEN",
+                "PRIVAT_DARLEHEN",
+                "REGIONAL_FOERDER_DARLEHEN",
+                "VARIABLES_DARLEHEN",
+                "ZWISCHEN_FINANZIERUNG"
               ]
             },
             "effektivZins": {
@@ -4029,7 +4084,8 @@
               "type": "number"
             },
             "vertriebsProvisionGesamtAbsolut": {
-              "type": "number"
+              "type": "number",
+              "description": "Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet."
             },
             "zinsBindungInMonaten": {
               "type": "integer",
@@ -4201,7 +4257,13 @@
             "darlehensTyp": {
               "type": "string",
               "enum": [
-                "REGIONAL_FOERDER_DARLEHEN"
+                "ANNUITAETEN_DARLEHEN",
+                "FORWARD_DARLEHEN",
+                "KFW_DARLEHEN",
+                "PRIVAT_DARLEHEN",
+                "REGIONAL_FOERDER_DARLEHEN",
+                "VARIABLES_DARLEHEN",
+                "ZWISCHEN_FINANZIERUNG"
               ]
             },
             "effektivZins": {
@@ -4238,7 +4300,8 @@
               "format": "int32"
             },
             "vertriebsProvisionGesamtAbsolut": {
-              "type": "number"
+              "type": "number",
+              "description": "Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet."
             },
             "zinsBindungInJahren": {
               "type": "integer",
@@ -4542,7 +4605,13 @@
             "darlehensTyp": {
               "type": "string",
               "enum": [
-                "VARIABLES_DARLEHEN"
+                "ANNUITAETEN_DARLEHEN",
+                "FORWARD_DARLEHEN",
+                "KFW_DARLEHEN",
+                "PRIVAT_DARLEHEN",
+                "REGIONAL_FOERDER_DARLEHEN",
+                "VARIABLES_DARLEHEN",
+                "ZWISCHEN_FINANZIERUNG"
               ]
             },
             "effektivZins": {
@@ -4568,7 +4637,8 @@
               "example": "2020-03-28"
             },
             "vertriebsProvisionGesamtAbsolut": {
-              "type": "number"
+              "type": "number",
+              "description": "Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet."
             }
           },
           "title": "VariablesDarlehen",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2,7 +2,7 @@
 swagger: "2.0"
 info:
   description: Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Kontext des Produktanbieters eingenommen.
-  version: "2.31"
+  version: "2.32"
   title: Anträge API
   contact:
     name: Europace AG
@@ -11,82 +11,82 @@ info:
 host: baufismart.api.europace.de
 basePath: /
 tags:
-- name: Anträge
-  description: Zugriff auf Anträge für die Kreditentscheidung
+  - name: Anträge
+    description: Zugriff auf Anträge für die Kreditentscheidung
 schemes:
-- https
+  - https
 paths:
   /v2/antraege:
     get:
       tags:
-      - Anträge
+        - Anträge
       summary: Alle Anträge abrufen
       description: "Es werden alle Anträge ausgeliefert, die der authentifizierten Partner sehen darf. Offen: Sortierung, Pagination, Filterung"
       operationId: getAlleAntraege
       produces:
-      - application/json;charset=UTF-8
+        - application/json;charset=UTF-8
       parameters:
-      - name: aenderungBis
-        in: query
-        description: Datum im ISO Format UTC - Zulu
-        required: false
-        type: string
-        x-example: 2016-03-11T10:57:45Z
-      - name: aenderungSeit
-        in: query
-        description: Datum im ISO Format UTC - Zulu
-        required: false
-        type: string
-        x-example: 2016-03-11T10:57:45Z
-      - name: angenommenNach
-        in: query
-        description: Datum im ISO Format UTC - Zulu
-        required: false
-        type: string
-        x-example: 2016-03-11T10:57:45Z
-      - name: antragsReferenz
-        in: query
-        description: Suche nach deiner antragsReferenz
-        required: false
-        type: string
-      - name: datenKontext
-        in: query
-        description: Datenkontext
-        required: false
-        type: string
-        default: ECHT_GESCHAEFT
-        enum:
-        - ECHT_GESCHAEFT
-        - TEST_MODUS
-      - name: limit
-        in: query
-        description: limit
-        required: false
-        type: integer
-        default: 10
-        format: int32
-      - name: page
-        in: query
-        description: page
-        required: false
-        type: integer
-        default: 0
-        format: int32
-      - name: produktAnbieter
-        in: query
-        description: produktAnbieter
-        required: false
-        type: string
-      - name: sort
-        in: query
-        description: "Sortierung der Anträge, aufsteigend oder absteigend"
-        required: false
-        type: string
-        default: absteigend
-      - name: X-TraceId
-        in: header
-        required: false
-        type: string
+        - name: aenderungBis
+          in: query
+          description: Datum im ISO Format UTC - Zulu
+          required: false
+          type: string
+          x-example: 2016-03-11T10:57:45Z
+        - name: aenderungSeit
+          in: query
+          description: Datum im ISO Format UTC - Zulu
+          required: false
+          type: string
+          x-example: 2016-03-11T10:57:45Z
+        - name: angenommenNach
+          in: query
+          description: Datum im ISO Format UTC - Zulu
+          required: false
+          type: string
+          x-example: 2016-03-11T10:57:45Z
+        - name: antragsReferenz
+          in: query
+          description: Suche nach deiner antragsReferenz
+          required: false
+          type: string
+        - name: datenKontext
+          in: query
+          description: Datenkontext
+          required: false
+          type: string
+          default: ECHT_GESCHAEFT
+          enum:
+            - ECHT_GESCHAEFT
+            - TEST_MODUS
+        - name: limit
+          in: query
+          description: limit
+          required: false
+          type: integer
+          default: 10
+          format: int32
+        - name: page
+          in: query
+          description: page
+          required: false
+          type: integer
+          default: 0
+          format: int32
+        - name: produktAnbieter
+          in: query
+          description: produktAnbieter
+          required: false
+          type: string
+        - name: sort
+          in: query
+          description: "Sortierung der Anträge, aufsteigend oder absteigend"
+          required: false
+          type: string
+          default: absteigend
+        - name: X-TraceId
+          in: header
+          required: false
+          type: string
       responses:
         "200":
           description: OK
@@ -117,28 +117,28 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
-      - OAuth2:
-        - baufinanzierung:antrag:lesen
+        - OAuth2:
+            - baufinanzierung:antrag:lesen
   /v2/antraege/{vorgang}:
     get:
       tags:
-      - Anträge
+        - Anträge
       summary: Alle Anträge eines Vorgangs abrufen
       description: Als Parameter wird die Vorgangsnummer in der Form 'AB1234' verwendet.
       operationId: getAntraegeByVorgangNummer
       produces:
-      - application/json;charset=UTF-8
+        - application/json;charset=UTF-8
       parameters:
-      - name: vorgang
-        in: path
-        description: Nummer des Antrags
-        required: true
-        type: string
-        x-example: AB1234
-      - name: X-TraceId
-        in: header
-        required: false
-        type: string
+        - name: vorgang
+          in: path
+          description: Nummer des Antrags
+          required: true
+          type: string
+          x-example: AB1234
+        - name: X-TraceId
+          in: header
+          required: false
+          type: string
       responses:
         "200":
           description: OK
@@ -169,34 +169,34 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
-      - OAuth2:
-        - baufinanzierung:antrag:lesen
+        - OAuth2:
+            - baufinanzierung:antrag:lesen
   /v2/antraege/{vorgang}/{antrag}:
     get:
       tags:
-      - Anträge
+        - Anträge
       summary: Teilanträge eines Antrags abrufen
       description: Als Parameter wird die Vorgangs- und Antragsnummer in der Form 'AB1234/1' verwendet.
       operationId: getAntrag
       produces:
-      - application/json;charset=UTF-8
+        - application/json;charset=UTF-8
       parameters:
-      - name: antrag
-        in: path
-        description: antrag
-        required: true
-        type: integer
-        format: int32
-      - name: vorgang
-        in: path
-        description: Nummer des Antrags
-        required: true
-        type: string
-        x-example: AB1234/1
-      - name: X-TraceId
-        in: header
-        required: false
-        type: string
+        - name: antrag
+          in: path
+          description: antrag
+          required: true
+          type: integer
+          format: int32
+        - name: vorgang
+          in: path
+          description: Nummer des Antrags
+          required: true
+          type: string
+          x-example: AB1234/1
+        - name: X-TraceId
+          in: header
+          required: false
+          type: string
       responses:
         "200":
           description: OK
@@ -227,34 +227,34 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
-      - OAuth2:
-        - baufinanzierung:antrag:lesen
+        - OAuth2:
+            - baufinanzierung:antrag:lesen
   /v2/antraege/{vorgang}/{antrag}/angebot:
     get:
       tags:
-      - Anträge
+        - Anträge
       summary: Angebot des Antrags abrufen
       description: "Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat.  Nutze den Endpunkt /{vorgang}/{antrag}/{teilAntrag}/angebot"
       operationId: getAngebot_1
       produces:
-      - application/json;charset=UTF-8
+        - application/json;charset=UTF-8
       parameters:
-      - name: antrag
-        in: path
-        description: antrag
-        required: true
-        type: integer
-        format: int32
-      - name: vorgang
-        in: path
-        description: "Nummer des Antrags, bestehend aus Vorgangsnummer und Antragnummer."
-        required: true
-        type: string
-        x-example: AB1234/1
-      - name: X-TraceId
-        in: header
-        required: false
-        type: string
+        - name: antrag
+          in: path
+          description: antrag
+          required: true
+          type: integer
+          format: int32
+        - name: vorgang
+          in: path
+          description: "Nummer des Antrags, bestehend aus Vorgangsnummer und Antragnummer."
+          required: true
+          type: string
+          x-example: AB1234/1
+        - name: X-TraceId
+          in: header
+          required: false
+          type: string
       responses:
         "200":
           description: OK
@@ -285,41 +285,41 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
-      - OAuth2:
-        - baufinanzierung:antrag:lesen
+        - OAuth2:
+            - baufinanzierung:antrag:lesen
       deprecated: true
   /v2/antraege/{vorgang}/{antrag}/{teilantrag}:
     get:
       tags:
-      - Anträge
+        - Anträge
       summary: Einzelnen Antrag abrufen
       description: Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.
       operationId: getAntrag_1
       produces:
-      - application/json;charset=UTF-8
+        - application/json;charset=UTF-8
       parameters:
-      - name: antrag
-        in: path
-        description: antrag
-        required: true
-        type: integer
-        format: int32
-      - name: teilantrag
-        in: path
-        description: teilantrag
-        required: true
-        type: integer
-        format: int32
-      - name: vorgang
-        in: path
-        description: Nummer des Antrags
-        required: true
-        type: string
-        x-example: AB1234/1/2
-      - name: X-TraceId
-        in: header
-        required: false
-        type: string
+        - name: antrag
+          in: path
+          description: antrag
+          required: true
+          type: integer
+          format: int32
+        - name: teilantrag
+          in: path
+          description: teilantrag
+          required: true
+          type: integer
+          format: int32
+        - name: vorgang
+          in: path
+          description: Nummer des Antrags
+          required: true
+          type: string
+          x-example: AB1234/1/2
+        - name: X-TraceId
+          in: header
+          required: false
+          type: string
       responses:
         "200":
           description: OK
@@ -350,58 +350,58 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
-      - OAuth2:
-        - baufinanzierung:antrag:lesen
+        - OAuth2:
+            - baufinanzierung:antrag:lesen
     patch:
       tags:
-      - Anträge
+        - Anträge
       summary: Antrag aktualisieren
       description: Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet. Es können mehrere Operationen gleichzeitig übertragen werden.
       operationId: updateAntrag
       consumes:
-      - application/json-patch+json
-      - application/json
+        - application/json-patch+json
+        - application/json
       produces:
-      - '*/*'
+        - '*/*'
       parameters:
-      - name: antrag
-        in: path
-        description: antrag
-        required: true
-        type: integer
-        format: int32
-      - name: Authorization
-        in: header
-        required: false
-        type: string
-      - in: body
-        name: patchOperations
-        description: patchOperations
-        required: true
-        schema:
-          type: array
-          items:
-            $ref: '#/definitions/PatchOperation'
-      - name: teilantrag
-        in: path
-        description: teilantrag
-        required: true
-        type: integer
-        format: int32
-      - name: vorgang
-        in: path
-        description: Nummer des Antrags
-        required: true
-        type: string
-        x-example: AB1234/1/2
-      - name: X-Authentication
-        in: header
-        required: false
-        type: string
-      - name: X-TraceId
-        in: header
-        required: false
-        type: string
+        - name: antrag
+          in: path
+          description: antrag
+          required: true
+          type: integer
+          format: int32
+        - name: Authorization
+          in: header
+          required: false
+          type: string
+        - in: body
+          name: patchOperations
+          description: patchOperations
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/PatchOperation'
+        - name: teilantrag
+          in: path
+          description: teilantrag
+          required: true
+          type: integer
+          format: int32
+        - name: vorgang
+          in: path
+          description: Nummer des Antrags
+          required: true
+          type: string
+          x-example: AB1234/1/2
+        - name: X-Authentication
+          in: header
+          required: false
+          type: string
+        - name: X-TraceId
+          in: header
+          required: false
+          type: string
       responses:
         "204":
           description: No Content
@@ -410,40 +410,40 @@ paths:
         "403":
           description: Forbidden
       security:
-      - OAuth2:
-        - baufinanzierung:antrag:schreiben
+        - OAuth2:
+            - baufinanzierung:antrag:schreiben
   /v2/antraege/{vorgang}/{antrag}/{teilantrag}/angebot:
     get:
       tags:
-      - Anträge
+        - Anträge
       summary: Angebot des Antrags abrufen
       description: "Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat."
       operationId: getAngebot
       produces:
-      - application/json;charset=UTF-8
+        - application/json;charset=UTF-8
       parameters:
-      - name: antrag
-        in: path
-        description: antrag
-        required: true
-        type: integer
-        format: int32
-      - name: teilantrag
-        in: path
-        description: teilantrag
-        required: true
-        type: integer
-        format: int32
-      - name: vorgang
-        in: path
-        description: "Nummer des Antrags, bestehend aus Vorgangsnummer und Antragnummer."
-        required: true
-        type: string
-        x-example: AB1234/1
-      - name: X-TraceId
-        in: header
-        required: false
-        type: string
+        - name: antrag
+          in: path
+          description: antrag
+          required: true
+          type: integer
+          format: int32
+        - name: teilantrag
+          in: path
+          description: teilantrag
+          required: true
+          type: integer
+          format: int32
+        - name: vorgang
+          in: path
+          description: "Nummer des Antrags, bestehend aus Vorgangsnummer und Antragnummer."
+          required: true
+          type: string
+          x-example: AB1234/1
+        - name: X-TraceId
+          in: header
+          required: false
+          type: string
       responses:
         "200":
           description: OK
@@ -474,42 +474,42 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
-      - OAuth2:
-        - baufinanzierung:antrag:lesen
+        - OAuth2:
+            - baufinanzierung:antrag:lesen
   /v2/antraege/{vorgang}/{antrag}/{teilantrag}/angebot/zahlungsplaene:
     get:
       tags:
-      - Anträge
+        - Anträge
       summary: Die Zahlungsplaene (Tilgungs- & Sparpläne) des angenommenen Angebots.
       description: Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.
       operationId: getZahlungsplaene
       produces:
-      - application/json;charset=UTF-8
+        - application/json;charset=UTF-8
       parameters:
-      - name: antrag
-        in: path
-        description: Nummer des Antrags
-        required: true
-        type: integer
-        format: int32
-        x-example: 1
-      - name: teilantrag
-        in: path
-        description: Nummer des Teilantrags
-        required: true
-        type: integer
-        format: int32
-        x-example: 1
-      - name: vorgang
-        in: path
-        description: Nummer des Vorgangs
-        required: true
-        type: string
-        x-example: AB1234
-      - name: X-TraceId
-        in: header
-        required: false
-        type: string
+        - name: antrag
+          in: path
+          description: Nummer des Antrags
+          required: true
+          type: integer
+          format: int32
+          x-example: 1
+        - name: teilantrag
+          in: path
+          description: Nummer des Teilantrags
+          required: true
+          type: integer
+          format: int32
+          x-example: 1
+        - name: vorgang
+          in: path
+          description: Nummer des Vorgangs
+          required: true
+          type: string
+          x-example: AB1234
+        - name: X-TraceId
+          in: header
+          required: false
+          type: string
       responses:
         "200":
           description: OK
@@ -540,40 +540,40 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
-      - OAuth2:
-        - baufinanzierung:antrag:lesen
+        - OAuth2:
+            - baufinanzierung:antrag:lesen
   /v2/antraege/{vorgang}/{antrag}/{teilantrag}/ansprechpartner:
     get:
       tags:
-      - Anträge
+        - Anträge
       summary: Den Ansprechpartner (Vertrieb) des  Teilantrags abrufen.
       description: Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.
       operationId: getAnsprechpartner
       produces:
-      - application/json;charset=UTF-8
+        - application/json;charset=UTF-8
       parameters:
-      - name: antrag
-        in: path
-        description: antrag
-        required: true
-        type: integer
-        format: int32
-      - name: teilantrag
-        in: path
-        description: teilantrag
-        required: true
-        type: integer
-        format: int32
-      - name: vorgang
-        in: path
-        description: Nummer des Antrags
-        required: true
-        type: string
-        x-example: AB1234/1/2
-      - name: X-TraceId
-        in: header
-        required: false
-        type: string
+        - name: antrag
+          in: path
+          description: antrag
+          required: true
+          type: integer
+          format: int32
+        - name: teilantrag
+          in: path
+          description: teilantrag
+          required: true
+          type: integer
+          format: int32
+        - name: vorgang
+          in: path
+          description: Nummer des Antrags
+          required: true
+          type: string
+          x-example: AB1234/1/2
+        - name: X-TraceId
+          in: header
+          required: false
+          type: string
       responses:
         "200":
           description: OK
@@ -604,56 +604,56 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security:
-      - OAuth2:
-        - baufinanzierung:antrag:lesen
+        - OAuth2:
+            - baufinanzierung:antrag:lesen
   /v2/antraege/{vorgang}/{antrag}/{teilantrag}/gegenangebot:
     post:
       tags:
-      - Anträge
+        - Anträge
       summary: Ein Gegenangebot erstellen
       description: Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet. Das übergebene Angebot wird sofort als Gegenangebot gestellt. Der alte Antrag wird abgelehnt.
       operationId: erstelleGegenangebot
       consumes:
-      - application/json
+        - application/json
       produces:
-      - application/json
+        - application/json
       parameters:
-      - name: antrag
-        in: path
-        description: antrag
-        required: true
-        type: integer
-        format: int32
-      - name: Authorization
-        in: header
-        required: false
-        type: string
-      - in: body
-        name: gegenangebot
-        description: gegenangebot
-        required: true
-        schema:
-          $ref: '#/definitions/Gegenangebot'
-      - name: teilantrag
-        in: path
-        description: teilantrag
-        required: true
-        type: integer
-        format: int32
-      - name: vorgang
-        in: path
-        description: Nummer des Antrags
-        required: true
-        type: string
-        x-example: AB1234/1/2
-      - name: X-Authentication
-        in: header
-        required: false
-        type: string
-      - name: X-TraceId
-        in: header
-        required: false
-        type: string
+        - name: antrag
+          in: path
+          description: antrag
+          required: true
+          type: integer
+          format: int32
+        - name: Authorization
+          in: header
+          required: false
+          type: string
+        - in: body
+          name: gegenangebot
+          description: gegenangebot
+          required: true
+          schema:
+            $ref: '#/definitions/Gegenangebot'
+        - name: teilantrag
+          in: path
+          description: teilantrag
+          required: true
+          type: integer
+          format: int32
+        - name: vorgang
+          in: path
+          description: Nummer des Antrags
+          required: true
+          type: string
+          x-example: AB1234/1/2
+        - name: X-Authentication
+          in: header
+          required: false
+          type: string
+        - name: X-TraceId
+          in: header
+          required: false
+          type: string
       responses:
         "201":
           description: Created
@@ -670,55 +670,55 @@ paths:
         "404":
           description: Not Found
       security:
-      - OAuth2:
-        - baufinanzierung:antrag:schreiben
-        - baufinanzierung:echtgeschaeft
+        - OAuth2:
+            - baufinanzierung:antrag:schreiben
+            - baufinanzierung:echtgeschaeft
   /v2/antraege/{vorgang}/{antrag}/{teilantrag}/status:
     post:
       tags:
-      - Anträge
+        - Anträge
       summary: Setzen des Antragsstatus
       operationId: setAntragsStatus_1
       consumes:
-      - application/json
+        - application/json
       produces:
-      - application/json;charset=UTF-8
+        - application/json;charset=UTF-8
       parameters:
-      - name: antrag
-        in: path
-        description: antrag
-        required: true
-        type: integer
-        format: int32
-      - name: Authorization
-        in: header
-        required: false
-        type: string
-      - in: body
-        name: statusDTO
-        description: statusDTO
-        required: true
-        schema:
-          $ref: '#/definitions/StatusDTO'
-      - name: teilantrag
-        in: path
-        description: teilantrag
-        required: true
-        type: integer
-        format: int32
-      - name: vorgang
-        in: path
-        description: vorgang
-        required: true
-        type: string
-      - name: X-Authentication
-        in: header
-        required: false
-        type: string
-      - name: X-TraceId
-        in: header
-        required: false
-        type: string
+        - name: antrag
+          in: path
+          description: antrag
+          required: true
+          type: integer
+          format: int32
+        - name: Authorization
+          in: header
+          required: false
+          type: string
+        - in: body
+          name: statusDTO
+          description: statusDTO
+          required: true
+          schema:
+            $ref: '#/definitions/StatusDTO'
+        - name: teilantrag
+          in: path
+          description: teilantrag
+          required: true
+          type: integer
+          format: int32
+        - name: vorgang
+          in: path
+          description: vorgang
+          required: true
+          type: string
+        - name: X-Authentication
+          in: header
+          required: false
+          type: string
+        - name: X-TraceId
+          in: header
+          required: false
+          type: string
       responses:
         "201":
           description: Created
@@ -731,8 +731,8 @@ paths:
         "404":
           description: Not Found
       security:
-      - OAuth2:
-        - baufinanzierung:antrag:schreiben
+        - OAuth2:
+            - baufinanzierung:antrag:schreiben
 securityDefinitions:
   Bearer:
     type: apiKey
@@ -761,11 +761,11 @@ definitions:
       praemienZahlungsweise:
         type: string
         enum:
-        - EINMALIG
-        - HALBJAEHRLICH
-        - JAEHRLICH
-        - MONATLICH
-        - VIERTELJAEHRLICH
+          - EINMALIG
+          - HALBJAEHRLICH
+          - JAEHRLICH
+          - MONATLICH
+          - VIERTELJAEHRLICH
       tarifBezeichnung:
         type: string
       tarifKennung:
@@ -803,8 +803,8 @@ definitions:
       bewertungDesAngebots:
         type: string
         enum:
-        - ANGEBOT_ENTSPRICHT_DEM_WUNSCH_DES_KUNDEN
-        - ANGEBOT_ENTSPRICHT_DER_EMPFEHLUNG_DES_KUNDENBETREUERS
+          - ANGEBOT_ENTSPRICHT_DEM_WUNSCH_DES_KUNDEN
+          - ANGEBOT_ENTSPRICHT_DER_EMPFEHLUNG_DES_KUNDENBETREUERS
       bonitaet:
         type: array
         items:
@@ -822,9 +822,9 @@ definitions:
       machbarkeitsStatus:
         type: string
         enum:
-        - MACHBAR
-        - NICHT_MACHBAR
-        - UNTER_VORBEHALT_PRODUZENT
+          - MACHBAR
+          - NICHT_MACHBAR
+          - UNTER_VORBEHALT_PRODUZENT
       meldungen:
         type: array
         items:
@@ -846,60 +846,67 @@ definitions:
   AnnuitaetenDarlehen:
     title: AnnuitaetenDarlehen
     allOf:
-    - $ref: '#/definitions/GegenangebotDarlehen'
-    - type: object
-      required:
-      - anfaenglicheTilgung
-      - bereitstellungsZinsFreieZeitInMonaten
-      - darlehensBetrag
-      - darlehensTyp
-      - effektivZins
-      - laufzeitKalkulatorischInJahren
-      - rateMonatlich
-      - sollZins
-      - sonderTilgungJaehrlich
-      - vertriebsProvisionGesamtAbsolut
-      - zinsBindungInJahren
-      discriminator: darlehensTyp
-      properties:
-        anfaenglicheTilgung:
-          type: number
-        bereitstellungsZins:
-          type: number
-        bereitstellungsZinsFreieZeitInMonaten:
-          type: integer
-          format: int32
-        darlehensBetrag:
-          type: number
-        darlehensTyp:
-          type: string
-          enum:
-          - ANNUITAETEN_DARLEHEN
-        effektivZins:
-          type: number
-        laufzeitKalkulatorischInJahren:
-          type: integer
-          format: int32
-        produktDetails:
-          type: string
-          description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
-        rateMonatlich:
-          type: number
-        sollZins:
-          type: number
-        sonderTilgungJaehrlich:
-          type: number
-        tilgungsBeginnAm:
-          type: string
-          format: date-time
-          example: 2020-03-28
-        vertriebsProvisionGesamtAbsolut:
-          type: number
-        zinsBindungInJahren:
-          type: integer
-          format: int32
-      title: AnnuitaetenDarlehen
-      description: Erweitert GegenangebotDarlehen
+      - $ref: '#/definitions/GegenangebotDarlehen'
+      - type: object
+        required:
+          - anfaenglicheTilgung
+          - bereitstellungsZinsFreieZeitInMonaten
+          - darlehensBetrag
+          - darlehensTyp
+          - effektivZins
+          - laufzeitKalkulatorischInJahren
+          - rateMonatlich
+          - sollZins
+          - sonderTilgungJaehrlich
+          - vertriebsProvisionGesamtAbsolut
+          - zinsBindungInJahren
+        discriminator: darlehensTyp
+        properties:
+          anfaenglicheTilgung:
+            type: number
+          bereitstellungsZins:
+            type: number
+          bereitstellungsZinsFreieZeitInMonaten:
+            type: integer
+            format: int32
+          darlehensBetrag:
+            type: number
+          darlehensTyp:
+            type: string
+            enum:
+              - ANNUITAETEN_DARLEHEN
+              - FORWARD_DARLEHEN
+              - KFW_DARLEHEN
+              - PRIVAT_DARLEHEN
+              - REGIONAL_FOERDER_DARLEHEN
+              - VARIABLES_DARLEHEN
+              - ZWISCHEN_FINANZIERUNG
+          effektivZins:
+            type: number
+          laufzeitKalkulatorischInJahren:
+            type: integer
+            format: int32
+          produktDetails:
+            type: string
+            description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
+          rateMonatlich:
+            type: number
+          sollZins:
+            type: number
+          sonderTilgungJaehrlich:
+            type: number
+          tilgungsBeginnAm:
+            type: string
+            format: date-time
+            example: 2020-03-28
+          vertriebsProvisionGesamtAbsolut:
+            type: number
+            description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
+          zinsBindungInJahren:
+            type: integer
+            format: int32
+        title: AnnuitaetenDarlehen
+        description: Erweitert GegenangebotDarlehen
     description: Erweitert GegenangebotDarlehen
   Anschrift:
     type: object
@@ -947,8 +954,8 @@ definitions:
         type: string
         description: "Gibt an, ob es sich um einen Antrag aus dem Testmodus oder Echtgeschäft handelt"
         enum:
-        - ECHT_GESCHAEFT
-        - TEST_MODUS
+          - ECHT_GESCHAEFT
+          - TEST_MODUS
       dokumente:
         type: array
         description: "Enthält alle Plattformdokumente, freigegebene Dokumente des Vertriebs, sowie die hochgeladenen Dokumente des Produktanbieters."
@@ -998,38 +1005,38 @@ definitions:
         type: string
         description: Ablehnungsgrund des Produktanbieters
         enum:
-        - FINANZIELLE_SITUATION
-        - GEGENANGEBOT
-        - KEINE_ANGABE
-        - KRITERIEN
-        - NEGATIV_MERKMAL
-        - UNTERLAGEN_UNVOLLSTAENDIG
-        - WERTERMITTLUNG
+          - FINANZIELLE_SITUATION
+          - GEGENANGEBOT
+          - KEINE_ANGABE
+          - KRITERIEN
+          - NEGATIV_MERKMAL
+          - UNTERLAGEN_UNVOLLSTAENDIG
+          - WERTERMITTLUNG
       antragsteller:
         type: string
         description: Willenserklärung des Antragstellers
         enum:
-        - BEANTRAGT
-        - NICHT_ANGENOMMEN
-        - UNTERSCHRIEBEN
-        - WIDERRUFEN
+          - BEANTRAGT
+          - NICHT_ANGENOMMEN
+          - UNTERSCHRIEBEN
+          - WIDERRUFEN
       bearbeitungsFortschritt:
         type: string
         description: Bearbeitungsfortschritt des Antrags nach beidseitiger Unterzeichnung
         enum:
-        - FREIGEGEBEN_FUER_SAMMELFORDERUNG
-        - NICHT_VON_PRODUKTANBIETER_BESTAETIGT
-        - PROVISION_IN_BEARBEITUNG
-        - PROVISON_AN_KUNDENBETREUER_VOLLSTAENDIG_AUSGEZAHLT
-        - VON_PRODUKTANBIETER_BESTAETIGT
+          - FREIGEGEBEN_FUER_SAMMELFORDERUNG
+          - NICHT_VON_PRODUKTANBIETER_BESTAETIGT
+          - PROVISION_IN_BEARBEITUNG
+          - PROVISON_AN_KUNDENBETREUER_VOLLSTAENDIG_AUSGEZAHLT
+          - VON_PRODUKTANBIETER_BESTAETIGT
       produktAnbieter:
         type: string
         description: Willenserklärung des Produktanbieters
         enum:
-        - ABGELEHNT
-        - NICHT_BEARBEITET
-        - UNTERSCHRIEBEN
-        - ZURUECKGESTELLT
+          - ABGELEHNT
+          - NICHT_BEARBEITET
+          - UNTERSCHRIEBEN
+          - ZURUECKGESTELLT
     title: AntragsStatus
   Antragsteller:
     type: object
@@ -1039,8 +1046,8 @@ definitions:
       anrede:
         type: string
         enum:
-        - FRAU
-        - HERR
+          - FRAU
+          - HERR
       anschrift:
         $ref: '#/definitions/Postadresse'
       arbeitserlaubnis:
@@ -1054,10 +1061,10 @@ definitions:
         type: string
         description: wenn der Antragssteller die Staatsangehörigkeit eines Nicht-EU-Landes hat
         enum:
-        - AUFENTHALTS_ERLAUBNIS
-        - DAUERAUFENTHALT_EU
-        - NIEDERLASSUNGS_ERLAUBNIS
-        - VISUM
+          - AUFENTHALTS_ERLAUBNIS
+          - DAUERAUFENTHALT_EU
+          - NIEDERLASSUNGS_ERLAUBNIS
+          - VISUM
       aufenthaltsTitelBefristetBis:
         type: string
         format: date
@@ -1094,12 +1101,12 @@ definitions:
       familienstand:
         type: string
         enum:
-        - GESCHIEDEN
-        - GETRENNT_LEBEND
-        - LEBENSPARTNERSCHAFT
-        - LEDIG
-        - VERHEIRATET
-        - VERWITWET
+          - GESCHIEDEN
+          - GETRENNT_LEBEND
+          - LEBENSPARTNERSCHAFT
+          - LEDIG
+          - VERHEIRATET
+          - VERWITWET
       geburtsdatum:
         type: string
         format: date
@@ -1167,8 +1174,8 @@ definitions:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-        - AUSGABE
-        - EINNAHME
+          - AUSGABE
+          - EINNAHME
     title: AusgabenMonatlich
   Autostellplatz:
     type: object
@@ -1178,12 +1185,12 @@ definitions:
       typ:
         type: string
         enum:
-        - CARPORT
-        - DOPPEL_GARAGE
-        - GARAGE
-        - KELLER_GARAGE
-        - STELLPLATZ
-        - TIEFGARAGEN_STELLPLATZ
+          - CARPORT
+          - DOPPEL_GARAGE
+          - GARAGE
+          - KELLER_GARAGE
+          - STELLPLATZ
+          - TIEFGARAGEN_STELLPLATZ
     title: Autostellplatz
   BankUndSparguthaben:
     type: object
@@ -1196,14 +1203,14 @@ definitions:
         type: string
         description: Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium
         enum:
-        - VERBINDLICHKEIT
-        - VERMOEGEN
+          - VERBINDLICHKEIT
+          - VERMOEGEN
       zahlungsTyp:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-        - AUSGABE
-        - EINNAHME
+          - AUSGABE
+          - EINNAHME
       zinsertragJaehrlich:
         type: number
     title: BankUndSparguthaben
@@ -1234,8 +1241,8 @@ definitions:
         type: string
         description: "Erlaubte Werte sind: SOFORTZAHLUNG, VERRECHNUNG"
         enum:
-        - SOFORTZAHLUNG
-        - VERRECHNUNG
+          - SOFORTZAHLUNG
+          - VERRECHNUNG
       angebotsHinweisFuerAntragsteller:
         type: string
         description: nur bei neuen extern berechneten Bausparverträgen und bei Gegenangeboten
@@ -1292,8 +1299,8 @@ definitions:
         type: string
         description: "Erlaubte Werte sind: SOFORTZAHLUNG, VERRECHNUNG"
         enum:
-        - SOFORTZAHLUNG
-        - VERRECHNUNG
+          - SOFORTZAHLUNG
+          - VERRECHNUNG
       angebotsHinweisFuerAntragsteller:
         type: string
         description: nur bei neuen extern berechneten Bausparverträgen und bei Gegenangeboten
@@ -1374,9 +1381,9 @@ definitions:
       art:
         type: string
         enum:
-        - AUSSER_GESCHAEFTSRAUM_VERTRAG
-        - FERN_ABSATZ_GESCHAEFT
-        - PRAESENZ_GESCHAEFT
+          - AUSSER_GESCHAEFTSRAUM_VERTRAG
+          - FERN_ABSATZ_GESCHAEFT
+          - PRAESENZ_GESCHAEFT
       hinweisFuerProduktAnbieter:
         type: string
       istKundenBetreuerVerkaeuferOderMaklerDerImmobilie:
@@ -1412,8 +1419,8 @@ definitions:
         type: string
         description: "nur bei art==ANGESTELLTER,ARBEITER"
         enum:
-        - BEFRISTET
-        - UNBEFRISTET
+          - BEFRISTET
+          - UNBEFRISTET
       beruf:
         type: string
         description: nur bei art!=RENTNER
@@ -1472,9 +1479,9 @@ definitions:
       immobilienEinsatz:
         type: string
         enum:
-        - ALS_ZUSATZSICHERHEIT
-        - KEIN_EINSATZ
-        - VERKAUFEN
+          - ALS_ZUSATZSICHERHEIT
+          - KEIN_EINSATZ
+          - VERKAUFEN
       keinBaulandFlaecheInQm:
         type: number
         description: "Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt."
@@ -1486,9 +1493,9 @@ definitions:
       objektArt:
         type: string
         enum:
-        - EIGENTUMSWOHNUNG
-        - GRUNDSTUECK
-        - HAUS
+          - EIGENTUMSWOHNUNG
+          - GRUNDSTUECK
+          - HAUS
       vergleichsmieteFuerGewerbeflaecheProQm:
         type: number
         description: "Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt."
@@ -1535,15 +1542,15 @@ definitions:
       vermoegensEinsatz:
         type: string
         enum:
-        - ABTRETEN
-        - AUFLOESEN
-        - KEIN_EINSATZ
+          - ABTRETEN
+          - AUFLOESEN
+          - KEIN_EINSATZ
       vermoegensTyp:
         type: string
         description: Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium
         enum:
-        - VERBINDLICHKEIT
-        - VERMOEGEN
+          - VERBINDLICHKEIT
+          - VERMOEGEN
       vertragsBeginn:
         type: string
         format: date
@@ -1555,8 +1562,8 @@ definitions:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-        - AUSGABE
-        - EINNAHME
+          - AUSGABE
+          - EINNAHME
       zuteilungsDatum:
         type: string
         format: date
@@ -1566,20 +1573,21 @@ definitions:
     properties:
       abzuloesendeRestschuld:
         type: number
+        description: Deprecated.
       aktuelleRestschuldWennNichtAbzuloesen:
         type: number
-        description: nur wenn wirdAbgeloest==true
+        description: Deprecated. nur wenn wirdAbgeloest==true
       bausteinId:
         type: string
       darlehensArt:
         type: string
         description: "Erlaubte Werte sind: BAUSPARDARLEHEN,FOERDERDARLEHEN,IMMOBILIENDARLEHEN,PRIVATDARLEHEN,SONSTIGES_DARLEHEN. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können."
         enum:
-        - BAUSPARDARLEHEN
-        - FOERDERDARLEHEN
-        - IMMOBILIENDARLEHEN
-        - PRIVATDARLEHEN
-        - SONSTIGES_DARLEHEN
+          - BAUSPARDARLEHEN
+          - FOERDERDARLEHEN
+          - IMMOBILIENDARLEHEN
+          - PRIVATDARLEHEN
+          - SONSTIGES_DARLEHEN
       darlehensBetrag:
         type: number
         description: "für Prolongation, d.h. technisch: Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG"
@@ -1594,8 +1602,8 @@ definitions:
         type: string
         description: "Erlaubte Werte sind: BUCH_GRUNDSCHULD, BRIEF_GRUNDSCHULD. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können."
         enum:
-        - BRIEF_GRUNDSCHULD
-        - BUCH_GRUNDSCHULD
+          - BRIEF_GRUNDSCHULD
+          - BUCH_GRUNDSCHULD
       hauptKontonummerDslBank:
         type: string
         description: "für DSL Bank Prolongation, d.h. technisch: Produktanbieter ist 'DSL Bank' und Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG"
@@ -1606,11 +1614,20 @@ definitions:
         format: date
       rateMonatlich:
         type: number
+      restschuldAktuell:
+        type: number
+        description: Die aktuelle Restschuld bezüglich des Darlehens.
+      restschuldZumAbloeseTermin:
+        type: number
+        description: Die kalkulatorische Restschuld zum Ende der Zinsbindung.
       sollZins:
         type: number
       sondertilgungZumZinsBindungsEnde:
         type: number
         description: "für Prolongation, d.h. technisch: Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG"
+      wirdAbgeloest:
+        type: boolean
+        description: "true, wenn Darlehen abgelöst wird, ansonsten false"
       zinsBindungEndetAm:
         type: string
         format: date
@@ -1620,20 +1637,21 @@ definitions:
     properties:
       abzuloesendeRestschuld:
         type: number
+        description: Deprecated.
       aktuelleRestschuldWennNichtAbzuloesen:
         type: number
-        description: nur wenn wirdAbgeloest==true
+        description: Deprecated. nur wenn wirdAbgeloest==true
       bausteinId:
         type: string
       darlehensArt:
         type: string
         description: "Erlaubte Werte sind: BAUSPARDARLEHEN,FOERDERDARLEHEN,IMMOBILIENDARLEHEN,PRIVATDARLEHEN,SONSTIGES_DARLEHEN. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können."
         enum:
-        - BAUSPARDARLEHEN
-        - FOERDERDARLEHEN
-        - IMMOBILIENDARLEHEN
-        - PRIVATDARLEHEN
-        - SONSTIGES_DARLEHEN
+          - BAUSPARDARLEHEN
+          - FOERDERDARLEHEN
+          - IMMOBILIENDARLEHEN
+          - PRIVATDARLEHEN
+          - SONSTIGES_DARLEHEN
       darlehensBetrag:
         type: number
         description: "für Prolongation, d.h. technisch: Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG"
@@ -1648,8 +1666,8 @@ definitions:
         type: string
         description: "Erlaubte Werte sind: BUCH_GRUNDSCHULD, BRIEF_GRUNDSCHULD. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können."
         enum:
-        - BRIEF_GRUNDSCHULD
-        - BUCH_GRUNDSCHULD
+          - BRIEF_GRUNDSCHULD
+          - BUCH_GRUNDSCHULD
       hauptKontonummerDslBank:
         type: string
         description: "für DSL Bank Prolongation, d.h. technisch: Produktanbieter ist 'DSL Bank' und Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG"
@@ -1660,6 +1678,12 @@ definitions:
         format: date
       rateMonatlich:
         type: number
+      restschuldAktuell:
+        type: number
+        description: Die aktuelle Restschuld bezüglich des Darlehens.
+      restschuldZumAbloeseTermin:
+        type: number
+        description: Die kalkulatorische Restschuld zum Ende der Zinsbindung.
       sollZins:
         type: number
       sondertilgungZumZinsBindungsEnde:
@@ -1669,9 +1693,12 @@ definitions:
         type: string
         description: "Beschreibt wie das Darlehen im Zusammenhang mit dem Vorhaben, behandelt werden soll."
         enum:
-        - ABLOESEN
-        - TRITT_IM_RANG_ZURUECK
-        - TRITT_NICHT_IM_RANG_ZURUECK
+          - ABLOESEN
+          - TRITT_IM_RANG_ZURUECK
+          - TRITT_NICHT_IM_RANG_ZURUECK
+      wirdAbgeloest:
+        type: boolean
+        description: "true, wenn Darlehen abgelöst wird, ansonsten false"
       zinsBindungEndetAm:
         type: string
         format: date
@@ -1707,9 +1734,9 @@ definitions:
       typ:
         type: string
         enum:
-        - ING
-        - MHB
-        - S_RATING
+          - ING
+          - MHB
+          - S_RATING
       wert:
         type: string
         description: "Kann je nach Typ folgende Ausprägungen besitzen.\n\nFür Ausprägung ING erlaubte Werte: BANKEN_VERSICHERUNGEN, BAUGEWERBE, DIENSTLEISTUNGEN_SONSTIGE, EDV_BERATUNG, ENERGIE, ERZIEHUNG_UNTERRICHT, GESUNDHEITSWESEN, HANDEL, HANDWERK, HOTEL_GASTRONOMIE, LANDWIRTSCHAFT, OEFFENTLICHER_DIENST, PRODUKTION_INDUSTRIE, VERKEHR\n\nFür Ausprägung MHB erlaubte Werte: VERARBEITENDES_GEWERBE, BAU, HANDEL, VERKEHR_INFORMATION, DIENSTLEISTUNG, SONSTIGES\n\nFür Ausprägung S_RATING erlaubte Werte: BAUGEWERBE, DIENSTLEISTUNGEN, ENERGIE_UND_WASSERVERSORGUNG_BERGBAU, GEBIETSKOERPERSCHAFTEN_UND_SOZIALVERSICHERUNGEN, GESUNDHEITSWESEN, HANDEL, HOTEL_UND_GASTRONOMIE, KREDITINSTITUTE, LAND_UND_FORSTWIRTSCHAFT_FISCHEREI, OEFFENTLICHER_DIENST, ORGANISATIONEN_OHNE_ERWERBSZWECK_PRIVATE_HAUSHALTE, VERARBEITENDES_GEWERBE, VERKEHR_UND_NACHRICHTENUEBERMITTLUNG, VERSICHERUNGEN, SONSTIGE"
@@ -1735,13 +1762,13 @@ definitions:
       darlehensTyp:
         type: string
         enum:
-        - ANNUITAETEN_DARLEHEN
-        - FORWARD_DARLEHEN
-        - KFW_DARLEHEN
-        - PRIVAT_DARLEHEN
-        - REGIONAL_FOERDER_DARLEHEN
-        - VARIABLES_DARLEHEN
-        - ZWISCHEN_FINANZIERUNG
+          - ANNUITAETEN_DARLEHEN
+          - FORWARD_DARLEHEN
+          - KFW_DARLEHEN
+          - PRIVAT_DARLEHEN
+          - REGIONAL_FOERDER_DARLEHEN
+          - VARIABLES_DARLEHEN
+          - ZWISCHEN_FINANZIERUNG
       detailsZurVerwendung:
         type: string
         description: nur bei darlehensTyp==ZWISCHEN_FINANZIERUNG
@@ -1818,9 +1845,9 @@ definitions:
         type: string
         description: nur bei darlehensTyp==ZWISCHEN_FINANZIERUNG
         enum:
-        - SONSTIGE_VERWENDUNG
-        - VERKAUF_EINES_ANDEREN_OBJEKTS
-        - VORFINANZIERUNG_OEFFENTLICHER_MITTEL
+          - SONSTIGE_VERWENDUNG
+          - VERKAUF_EINES_ANDEREN_OBJEKTS
+          - VORFINANZIERUNG_OEFFENTLICHER_MITTEL
       zinsBindung:
         description: "nicht bei darlehensTyp IN [VARIABLES_DARLEHEN,ZWISCHEN_FINANZIERUNG]"
         $ref: '#/definitions/ZinsBindung'
@@ -1879,8 +1906,8 @@ definitions:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-        - AUSGABE
-        - EINNAHME
+          - AUSGABE
+          - EINNAHME
     title: EinkuenfteAusNebentaetigkeit
   EinnahmenMonatlich:
     type: object
@@ -1891,8 +1918,8 @@ definitions:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-        - AUSGABE
-        - EINNAHME
+          - AUSGABE
+          - EINNAHME
     title: EinnahmenMonatlich
   Eintrag:
     type: object
@@ -1915,16 +1942,16 @@ definitions:
       typ:
         type: string
         enum:
-        - AGGREGIERTER_EINTRAG
-        - EINTRAG
-        - SUMMEN_EINTRAG_ZUM_ZINSBINDUNGSENDE
+          - AGGREGIERTER_EINTRAG
+          - EINTRAG
+          - SUMMEN_EINTRAG_ZUM_ZINSBINDUNGSENDE
       zahlung:
         type: number
       zahlungsTyp:
         type: string
         enum:
-        - AUSZAHLUNG
-        - EINZAHLUNG
+          - AUSZAHLUNG
+          - EINZAHLUNG
       zinsen:
         type: number
     title: Eintrag
@@ -1936,8 +1963,8 @@ definitions:
       grundstuecksEigentuemer:
         type: string
         enum:
-        - ANDERE
-        - OEFFENTLICH_KIRCHLICH
+          - ANDERE
+          - OEFFENTLICH_KIRCHLICH
       laufzeitBisJahr:
         type: string
         example: "2016"
@@ -2036,9 +2063,9 @@ definitions:
       objektArt:
         type: string
         enum:
-        - EIGENTUMSWOHNUNG
-        - GRUNDSTUECK
-        - HAUS
+          - EIGENTUMSWOHNUNG
+          - GRUNDSTUECK
+          - HAUS
       vergleichsmieteFuerGewerbeflaecheProQm:
         type: number
         description: "Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt."
@@ -2070,64 +2097,71 @@ definitions:
   ForwardDarlehen:
     title: ForwardDarlehen
     allOf:
-    - $ref: '#/definitions/GegenangebotDarlehen'
-    - type: object
-      required:
-      - anfaenglicheTilgung
-      - bereitstellungsZinsFreieZeitInMonaten
-      - darlehensBetrag
-      - darlehensTyp
-      - effektivZins
-      - forwardPeriodeInMonaten
-      - laufzeitKalkulatorischInJahren
-      - rateMonatlich
-      - sollZins
-      - sonderTilgungJaehrlich
-      - vertriebsProvisionGesamtAbsolut
-      - zinsBindungInJahren
-      discriminator: darlehensTyp
-      properties:
-        anfaenglicheTilgung:
-          type: number
-        bereitstellungsZins:
-          type: number
-        bereitstellungsZinsFreieZeitInMonaten:
-          type: integer
-          format: int32
-        darlehensBetrag:
-          type: number
-        darlehensTyp:
-          type: string
-          enum:
-          - FORWARD_DARLEHEN
-        effektivZins:
-          type: number
-        forwardPeriodeInMonaten:
-          type: integer
-          format: int32
-        laufzeitKalkulatorischInJahren:
-          type: integer
-          format: int32
-        produktDetails:
-          type: string
-          description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
-        rateMonatlich:
-          type: number
-        sollZins:
-          type: number
-        sonderTilgungJaehrlich:
-          type: number
-        tilgungsBeginnAm:
-          type: string
-          format: date-time
-          example: 2020-03-28
-        vertriebsProvisionGesamtAbsolut:
-          type: number
-        zinsBindungInJahren:
-          type: integer
-          format: int32
-      title: ForwardDarlehen
-      description: Erweitert GegenangebotDarlehen
+      - $ref: '#/definitions/GegenangebotDarlehen'
+      - type: object
+        required:
+          - anfaenglicheTilgung
+          - bereitstellungsZinsFreieZeitInMonaten
+          - darlehensBetrag
+          - darlehensTyp
+          - effektivZins
+          - forwardPeriodeInMonaten
+          - laufzeitKalkulatorischInJahren
+          - rateMonatlich
+          - sollZins
+          - sonderTilgungJaehrlich
+          - vertriebsProvisionGesamtAbsolut
+          - zinsBindungInJahren
+        discriminator: darlehensTyp
+        properties:
+          anfaenglicheTilgung:
+            type: number
+          bereitstellungsZins:
+            type: number
+          bereitstellungsZinsFreieZeitInMonaten:
+            type: integer
+            format: int32
+          darlehensBetrag:
+            type: number
+          darlehensTyp:
+            type: string
+            enum:
+              - ANNUITAETEN_DARLEHEN
+              - FORWARD_DARLEHEN
+              - KFW_DARLEHEN
+              - PRIVAT_DARLEHEN
+              - REGIONAL_FOERDER_DARLEHEN
+              - VARIABLES_DARLEHEN
+              - ZWISCHEN_FINANZIERUNG
+          effektivZins:
+            type: number
+          forwardPeriodeInMonaten:
+            type: integer
+            format: int32
+          laufzeitKalkulatorischInJahren:
+            type: integer
+            format: int32
+          produktDetails:
+            type: string
+            description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
+          rateMonatlich:
+            type: number
+          sollZins:
+            type: number
+          sonderTilgungJaehrlich:
+            type: number
+          tilgungsBeginnAm:
+            type: string
+            format: date-time
+            example: 2020-03-28
+          vertriebsProvisionGesamtAbsolut:
+            type: number
+            description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
+          zinsBindungInJahren:
+            type: integer
+            format: int32
+        title: ForwardDarlehen
+        description: Erweitert GegenangebotDarlehen
     description: Erweitert GegenangebotDarlehen
   Gebaeude:
     type: object
@@ -2166,18 +2200,18 @@ definitions:
       hausAnordnung:
         type: string
         enum:
-        - FREISTEHEND
-        - KOPFHAUS
-        - MITTELHAUS
+          - FREISTEHEND
+          - KOPFHAUS
+          - MITTELHAUS
       hausTyp:
         type: string
         description: Nur bei ObjektArt == HAUS.
         enum:
-        - DOPPELHAUSHAELFTE
-        - EINFAMILIENHAUS
-        - MEHRFAMILIENHAUS
-        - REIHENHAUS
-        - ZWEIFAMILIENHAUS
+          - DOPPELHAUSHAELFTE
+          - EINFAMILIENHAUS
+          - MEHRFAMILIENHAUS
+          - REIHENHAUS
+          - ZWEIFAMILIENHAUS
       istFertighaus:
         type: boolean
         description: Nur bei ObjektArt == HAUS.
@@ -2204,11 +2238,11 @@ definitions:
         type: string
         description: Angaben zum Zustand der Immobilie für die automatische Objektbewertungs-Schnittstelle (VDP)
         enum:
-        - GUT
-        - MAESSIG
-        - MITTEL
-        - SCHLECHT
-        - SEHR_GUT
+          - GUT
+          - MAESSIG
+          - MITTEL
+          - SCHLECHT
+          - SEHR_GUT
     title: Gebaeude
   GebaeudeFlaeche:
     type: object
@@ -2221,7 +2255,7 @@ definitions:
   Gegenangebot:
     type: object
     required:
-    - darlehen
+      - darlehen
     properties:
       darlehen:
         type: array
@@ -2234,12 +2268,13 @@ definitions:
   GegenangebotDarlehen:
     type: object
     required:
-    - anfaenglicheTilgung
-    - darlehensBetrag
-    - effektivZins
-    - rateMonatlich
-    - sollZins
-    - vertriebsProvisionGesamtAbsolut
+      - anfaenglicheTilgung
+      - darlehensBetrag
+      - darlehensTyp
+      - effektivZins
+      - rateMonatlich
+      - sollZins
+      - vertriebsProvisionGesamtAbsolut
     discriminator: darlehensTyp
     properties:
       anfaenglicheTilgung:
@@ -2249,13 +2284,13 @@ definitions:
       darlehensTyp:
         type: string
         enum:
-        - ANNUITAETEN_DARLEHEN
-        - FORWARD_DARLEHEN
-        - KFW_DARLEHEN
-        - PRIVAT_DARLEHEN
-        - REGIONAL_FOERDER_DARLEHEN
-        - VARIABLES_DARLEHEN
-        - ZWISCHEN_FINANZIERUNG
+          - ANNUITAETEN_DARLEHEN
+          - FORWARD_DARLEHEN
+          - KFW_DARLEHEN
+          - PRIVAT_DARLEHEN
+          - REGIONAL_FOERDER_DARLEHEN
+          - VARIABLES_DARLEHEN
+          - ZWISCHEN_FINANZIERUNG
       effektivZins:
         type: number
       produktDetails:
@@ -2267,6 +2302,7 @@ definitions:
         type: number
       vertriebsProvisionGesamtAbsolut:
         type: number
+        description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
     title: GegenangebotDarlehen
     x-discriminator-is-enum: true
   GrundbuchAngabe:
@@ -2299,11 +2335,11 @@ definitions:
       grundstuecksArt:
         type: string
         enum:
-        - LANDWIRTSCHAFTLICHES_GRUNDSTUECK
-        - SONSTIGES_GRUNDSTUECK
-        - UNBEBAUTES_GEWERBEGRUNDSTUECK
-        - UNBEBAUTES_MISCHGRUNDSTUECK
-        - UNBEBAUTES_WOHNGRUNDSTUECK
+          - LANDWIRTSCHAFTLICHES_GRUNDSTUECK
+          - SONSTIGES_GRUNDSTUECK
+          - UNBEBAUTES_GEWERBEGRUNDSTUECK
+          - UNBEBAUTES_MISCHGRUNDSTUECK
+          - UNBEBAUTES_WOHNGRUNDSTUECK
     title: Grundstueck
   Haushalt:
     type: object
@@ -2436,78 +2472,85 @@ definitions:
   KfwDarlehen:
     title: KfwDarlehen
     allOf:
-    - $ref: '#/definitions/GegenangebotDarlehen'
-    - type: object
-      required:
-      - anfaenglicheTilgung
-      - bereitstellungsZins
-      - bereitstellungsZinsFreieZeitInMonaten
-      - darlehensBetrag
-      - darlehensTyp
-      - effektivZins
-      - kfwProgramm
-      - laufzeitKalkulatorischInJahren
-      - rateMonatlich
-      - rateMonatlichInDerTilgungsfreienAnlaufzeit
-      - sollZins
-      - tilgungsFreieAnlaufJahre
-      - vertriebsProvisionGesamtAbsolut
-      - zinsBindungInJahren
-      discriminator: darlehensTyp
-      properties:
-        anfaenglicheTilgung:
-          type: number
-        bereitstellungsZins:
-          type: number
-        bereitstellungsZinsFreieZeitInMonaten:
-          type: integer
-          format: int32
-        darlehensBetrag:
-          type: number
-        darlehensTyp:
-          type: string
-          enum:
-          - KFW_DARLEHEN
-        effektivZins:
-          type: number
-        kfwEnergieEffizienzStandard:
-          type: string
-          description: "Nur benötigt, wenn kfwProgramm = PROGRAMM_153"
-          enum:
-          - STANDARD_40
-          - STANDARD_40_PLUS
-          - STANDARD_55
-        kfwProgramm:
-          type: string
-          enum:
-          - PROGRAMM_124
-          - PROGRAMM_151
-          - PROGRAMM_152
-          - PROGRAMM_153
-          - PROGRAMM_159
-          - PROGRAMM_167
-        laufzeitKalkulatorischInJahren:
-          type: integer
-          format: int32
-        produktDetails:
-          type: string
-          description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
-        rateMonatlich:
-          type: number
-        rateMonatlichInDerTilgungsfreienAnlaufzeit:
-          type: number
-        sollZins:
-          type: number
-        tilgungsFreieAnlaufJahre:
-          type: integer
-          format: int32
-        vertriebsProvisionGesamtAbsolut:
-          type: number
-        zinsBindungInJahren:
-          type: integer
-          format: int32
-      title: KfwDarlehen
-      description: Erweitert GegenangebotDarlehen
+      - $ref: '#/definitions/GegenangebotDarlehen'
+      - type: object
+        required:
+          - anfaenglicheTilgung
+          - bereitstellungsZins
+          - bereitstellungsZinsFreieZeitInMonaten
+          - darlehensBetrag
+          - darlehensTyp
+          - effektivZins
+          - kfwProgramm
+          - laufzeitKalkulatorischInJahren
+          - rateMonatlich
+          - rateMonatlichInDerTilgungsfreienAnlaufzeit
+          - sollZins
+          - tilgungsFreieAnlaufJahre
+          - vertriebsProvisionGesamtAbsolut
+          - zinsBindungInJahren
+        discriminator: darlehensTyp
+        properties:
+          anfaenglicheTilgung:
+            type: number
+          bereitstellungsZins:
+            type: number
+          bereitstellungsZinsFreieZeitInMonaten:
+            type: integer
+            format: int32
+          darlehensBetrag:
+            type: number
+          darlehensTyp:
+            type: string
+            enum:
+              - ANNUITAETEN_DARLEHEN
+              - FORWARD_DARLEHEN
+              - KFW_DARLEHEN
+              - PRIVAT_DARLEHEN
+              - REGIONAL_FOERDER_DARLEHEN
+              - VARIABLES_DARLEHEN
+              - ZWISCHEN_FINANZIERUNG
+          effektivZins:
+            type: number
+          kfwEnergieEffizienzStandard:
+            type: string
+            description: "Nur benötigt, wenn kfwProgramm = PROGRAMM_153"
+            enum:
+              - STANDARD_40
+              - STANDARD_40_PLUS
+              - STANDARD_55
+          kfwProgramm:
+            type: string
+            enum:
+              - PROGRAMM_124
+              - PROGRAMM_151
+              - PROGRAMM_152
+              - PROGRAMM_153
+              - PROGRAMM_159
+              - PROGRAMM_167
+          laufzeitKalkulatorischInJahren:
+            type: integer
+            format: int32
+          produktDetails:
+            type: string
+            description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
+          rateMonatlich:
+            type: number
+          rateMonatlichInDerTilgungsfreienAnlaufzeit:
+            type: number
+          sollZins:
+            type: number
+          tilgungsFreieAnlaufJahre:
+            type: integer
+            format: int32
+          vertriebsProvisionGesamtAbsolut:
+            type: number
+            description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
+          zinsBindungInJahren:
+            type: integer
+            format: int32
+        title: KfwDarlehen
+        description: Erweitert GegenangebotDarlehen
     description: Erweitert GegenangebotDarlehen
   Kind:
     type: object
@@ -2538,23 +2581,23 @@ definitions:
       typ:
         type: string
         enum:
-        - FONDSGEBUNDENE_LEBENSVERSICHERUNG
-        - FONDSGEBUNDENE_RENTENVERSICHERUNG
-        - KAPITALBILDENDE_LEBENSVERSICHERUNG
-        - KAPITALBILDENDE_RENTENVERSICHERUNG
-        - RISIKO_LEBENSVERSICHERUNG
+          - FONDSGEBUNDENE_LEBENSVERSICHERUNG
+          - FONDSGEBUNDENE_RENTENVERSICHERUNG
+          - KAPITALBILDENDE_LEBENSVERSICHERUNG
+          - KAPITALBILDENDE_RENTENVERSICHERUNG
+          - RISIKO_LEBENSVERSICHERUNG
       vermoegensEinsatz:
         type: string
         enum:
-        - ABTRETEN
-        - AUFLOESEN
-        - KEIN_EINSATZ
+          - ABTRETEN
+          - AUFLOESEN
+          - KEIN_EINSATZ
       vermoegensTyp:
         type: string
         description: Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium
         enum:
-        - VERBINDLICHKEIT
-        - VERMOEGEN
+          - VERBINDLICHKEIT
+          - VERMOEGEN
       versicherungsGesellschaft:
         type: string
       versicherungsSumme:
@@ -2573,8 +2616,8 @@ definitions:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-        - AUSGABE
-        - EINNAHME
+          - AUSGABE
+          - EINNAHME
     title: LebensOderRentenversicherungVermoegen
   LegitimationsDaten:
     type: object
@@ -2587,9 +2630,9 @@ definitions:
       ausweisArt:
         type: string
         enum:
-        - ANDERE
-        - PERSONALAUSWEIS
-        - REISEPASS
+          - ANDERE
+          - PERSONALAUSWEIS
+          - REISEPASS
       ausweisArtBeiAndererAusweis:
         type: string
         description: Nur wenn ausweisArt = ANDERE
@@ -2634,8 +2677,8 @@ definitions:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-        - AUSGABE
-        - EINNAHME
+          - AUSGABE
+          - EINNAHME
     title: MietAusgaben
   MiteigentumsAnteil:
     type: object
@@ -2656,23 +2699,23 @@ definitions:
         type: string
         description: "Erlaubte Werte sind: UEBERWIEGEND,UMFASSEND,MITTEL,EINFACH. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können."
         enum:
-        - EINFACH
-        - MITTEL
-        - UEBERWIEGEND
-        - UMFASSEND
+          - EINFACH
+          - MITTEL
+          - UEBERWIEGEND
+          - UMFASSEND
       modernisierungsArt:
         type: string
         description: "Erlaubte Werte sind: KERNSANIERUNG, DACHERNEUERUNG, FENSTER, ROHRLEITUNGEN, HEIZUNG, WAERMEDAEMMUNG, BAEDER, INNENAUSBAU, RAUMAUFTEILUNG. Der Client muss daher mit unbekannten Werten umgehen können."
         enum:
-        - BAEDER
-        - DACHERNEUERUNG
-        - FENSTER
-        - HEIZUNG
-        - INNENAUSBAU
-        - KERNSANIERUNG
-        - RAUMAUFTEILUNG
-        - ROHRLEITUNGEN
-        - WAERMEDAEMMUNG
+          - BAEDER
+          - DACHERNEUERUNG
+          - FENSTER
+          - HEIZUNG
+          - INNENAUSBAU
+          - KERNSANIERUNG
+          - RAUMAUFTEILUNG
+          - ROHRLEITUNGEN
+          - WAERMEDAEMMUNG
     title: Modernisierung
   ModernisierungsAngaben:
     type: object
@@ -2775,12 +2818,12 @@ definitions:
         type: string
         description: Auszuführende Operation
         enum:
-        - add
-        - copy
-        - move
-        - remove
-        - replace
-        - test
+          - add
+          - copy
+          - move
+          - remove
+          - replace
+          - test
       path:
         type: string
         description: "JSON-Path im Antrag. Valide Pfade sind: '/antragsReferenz', '/status', '/status/antragsteller', '/ansprechpartner/partnerId', '/status/produktAnbieter', '/voraussichtlicheBearbeitung'."
@@ -2788,7 +2831,7 @@ definitions:
         type: object
         example: "\"WER123\", 1234, {\"antragsteller\": \"BEANTRAGT\"}"
         description: "Zu setzender oder auszutauschender Wert. Erlaubt sind string, number oder JSON object"
-        properties: {}
+        properties: { }
     title: PatchOperation
     description: "A JSONPatch document as defined by RFC 6902 (see http://jsonpatch.com/). Beispiel: { \"op\": \"replace\", \"path\": \"/antragsReferenz\", \"value\": \"123-ABC\"\" }"
   Postadresse:
@@ -2806,47 +2849,54 @@ definitions:
   PrivatDarlehen:
     title: PrivatDarlehen
     allOf:
-    - $ref: '#/definitions/GegenangebotDarlehen'
-    - type: object
-      required:
-      - anfaenglicheTilgung
-      - darlehensBetrag
-      - darlehensTyp
-      - effektivZins
-      - laufzeitKalkulatorischInMonaten
-      - rateMonatlich
-      - sollZins
-      - vertriebsProvisionGesamtAbsolut
-      - zinsBindungInMonaten
-      discriminator: darlehensTyp
-      properties:
-        anfaenglicheTilgung:
-          type: number
-        darlehensBetrag:
-          type: number
-        darlehensTyp:
-          type: string
-          enum:
-          - PRIVAT_DARLEHEN
-        effektivZins:
-          type: number
-        laufzeitKalkulatorischInMonaten:
-          type: integer
-          format: int32
-        produktDetails:
-          type: string
-          description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
-        rateMonatlich:
-          type: number
-        sollZins:
-          type: number
-        vertriebsProvisionGesamtAbsolut:
-          type: number
-        zinsBindungInMonaten:
-          type: integer
-          format: int32
-      title: PrivatDarlehen
-      description: Erweitert GegenangebotDarlehen
+      - $ref: '#/definitions/GegenangebotDarlehen'
+      - type: object
+        required:
+          - anfaenglicheTilgung
+          - darlehensBetrag
+          - darlehensTyp
+          - effektivZins
+          - laufzeitKalkulatorischInMonaten
+          - rateMonatlich
+          - sollZins
+          - vertriebsProvisionGesamtAbsolut
+          - zinsBindungInMonaten
+        discriminator: darlehensTyp
+        properties:
+          anfaenglicheTilgung:
+            type: number
+          darlehensBetrag:
+            type: number
+          darlehensTyp:
+            type: string
+            enum:
+              - ANNUITAETEN_DARLEHEN
+              - FORWARD_DARLEHEN
+              - KFW_DARLEHEN
+              - PRIVAT_DARLEHEN
+              - REGIONAL_FOERDER_DARLEHEN
+              - VARIABLES_DARLEHEN
+              - ZWISCHEN_FINANZIERUNG
+          effektivZins:
+            type: number
+          laufzeitKalkulatorischInMonaten:
+            type: integer
+            format: int32
+          produktDetails:
+            type: string
+            description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
+          rateMonatlich:
+            type: number
+          sollZins:
+            type: number
+          vertriebsProvisionGesamtAbsolut:
+            type: number
+            description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
+          zinsBindungInMonaten:
+            type: integer
+            format: int32
+        title: PrivatDarlehen
+        description: Erweitert GegenangebotDarlehen
     description: Erweitert GegenangebotDarlehen
   Problem:
     type: object
@@ -2930,69 +2980,76 @@ definitions:
   RegionalFoerderDarlehen:
     title: RegionalFoerderDarlehen
     allOf:
-    - $ref: '#/definitions/GegenangebotDarlehen'
-    - type: object
-      required:
-      - anfaenglicheTilgung
-      - bereitstellungsZins
-      - bereitstellungsZinsFreieZeitInMonaten
-      - darlehensBetrag
-      - darlehensTyp
-      - effektivZins
-      - laufzeitKalkulatorischInJahren
-      - rateMonatlich
-      - rateMonatlichInDerTilgungsfreienAnlaufzeit
-      - regionalFoerderbankProgramm
-      - sollZins
-      - tilgungsFreieAnlaufJahre
-      - vertriebsProvisionGesamtAbsolut
-      - zinsBindungInJahren
-      discriminator: darlehensTyp
-      properties:
-        anfaenglicheTilgung:
-          type: number
-        bereitstellungsZins:
-          type: number
-        bereitstellungsZinsFreieZeitInMonaten:
-          type: integer
-          format: int32
-        darlehensBetrag:
-          type: number
-        darlehensTyp:
-          type: string
-          enum:
-          - REGIONAL_FOERDER_DARLEHEN
-        effektivZins:
-          type: number
-        laufzeitKalkulatorischInJahren:
-          type: integer
-          format: int32
-        produktDetails:
-          type: string
-          description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
-        rateMonatlich:
-          type: number
-        rateMonatlichInDerTilgungsfreienAnlaufzeit:
-          type: number
-        regionalFoerderbankProgramm:
-          type: string
-          enum:
-          - L_BANK_KOMBI_DARLEHEN_WOHNEN
-          - L_BANK_WOHNEN_MIT_KIND
-          - L_BANK_WOHNEN_MIT_ZUKUNFT
-          - NRW_BANK_WOHNEIGENTUM
-        sollZins:
-          type: number
-        tilgungsFreieAnlaufJahre:
-          type: integer
-          format: int32
-        vertriebsProvisionGesamtAbsolut:
-          type: number
-        zinsBindungInJahren:
-          type: integer
-          format: int32
-      title: RegionalFoerderDarlehen
-      description: Erweitert GegenangebotDarlehen
+      - $ref: '#/definitions/GegenangebotDarlehen'
+      - type: object
+        required:
+          - anfaenglicheTilgung
+          - bereitstellungsZins
+          - bereitstellungsZinsFreieZeitInMonaten
+          - darlehensBetrag
+          - darlehensTyp
+          - effektivZins
+          - laufzeitKalkulatorischInJahren
+          - rateMonatlich
+          - rateMonatlichInDerTilgungsfreienAnlaufzeit
+          - regionalFoerderbankProgramm
+          - sollZins
+          - tilgungsFreieAnlaufJahre
+          - vertriebsProvisionGesamtAbsolut
+          - zinsBindungInJahren
+        discriminator: darlehensTyp
+        properties:
+          anfaenglicheTilgung:
+            type: number
+          bereitstellungsZins:
+            type: number
+          bereitstellungsZinsFreieZeitInMonaten:
+            type: integer
+            format: int32
+          darlehensBetrag:
+            type: number
+          darlehensTyp:
+            type: string
+            enum:
+              - ANNUITAETEN_DARLEHEN
+              - FORWARD_DARLEHEN
+              - KFW_DARLEHEN
+              - PRIVAT_DARLEHEN
+              - REGIONAL_FOERDER_DARLEHEN
+              - VARIABLES_DARLEHEN
+              - ZWISCHEN_FINANZIERUNG
+          effektivZins:
+            type: number
+          laufzeitKalkulatorischInJahren:
+            type: integer
+            format: int32
+          produktDetails:
+            type: string
+            description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
+          rateMonatlich:
+            type: number
+          rateMonatlichInDerTilgungsfreienAnlaufzeit:
+            type: number
+          regionalFoerderbankProgramm:
+            type: string
+            enum:
+              - L_BANK_KOMBI_DARLEHEN_WOHNEN
+              - L_BANK_WOHNEN_MIT_KIND
+              - L_BANK_WOHNEN_MIT_ZUKUNFT
+              - NRW_BANK_WOHNEIGENTUM
+          sollZins:
+            type: number
+          tilgungsFreieAnlaufJahre:
+            type: integer
+            format: int32
+          vertriebsProvisionGesamtAbsolut:
+            type: number
+            description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
+          zinsBindungInJahren:
+            type: integer
+            format: int32
+        title: RegionalFoerderDarlehen
+        description: Erweitert GegenangebotDarlehen
     description: Erweitert GegenangebotDarlehen
   RisikoAbsicherung:
     type: object
@@ -3000,23 +3057,23 @@ definitions:
       abgesichertesRisiko:
         type: string
         enum:
-        - ARBEITSLOSIGKEIT
-        - ARBEITSUNFAEHIGKEIT
-        - ASSISTANCE_ARBEITSLOSIGKEIT
-        - ASSISTANCE_ARBEITSUNFAEHIGKEIT
-        - INVALIDITAET
-        - SCHWERE_KRANKHEIT
-        - TODESFALL
+          - ARBEITSLOSIGKEIT
+          - ARBEITSUNFAEHIGKEIT
+          - ASSISTANCE_ARBEITSLOSIGKEIT
+          - ASSISTANCE_ARBEITSUNFAEHIGKEIT
+          - INVALIDITAET
+          - SCHWERE_KRANKHEIT
+          - TODESFALL
       auszahlungsBetrag:
         type: number
       auszahlungsTurnus:
         type: string
         enum:
-        - EINMALIG
-        - HALBJAEHRLICH
-        - JAEHRLICH
-        - MONATLICH
-        - VIERTELJAEHRLICH
+          - EINMALIG
+          - HALBJAEHRLICH
+          - JAEHRLICH
+          - MONATLICH
+          - VIERTELJAEHRLICH
       praemienAnteil:
         type: number
     title: RisikoAbsicherung
@@ -3059,11 +3116,11 @@ definitions:
       zahlweise:
         type: string
         enum:
-        - EINMALIG
-        - HALBJAEHRLICH
-        - JAEHRLICH
-        - MONATLICH
-        - VIERTELJAEHRLICH
+          - EINMALIG
+          - HALBJAEHRLICH
+          - JAEHRLICH
+          - MONATLICH
+          - VIERTELJAEHRLICH
     title: SonderZahlung
   SparPhase:
     type: object
@@ -3089,14 +3146,14 @@ definitions:
         type: string
         description: Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium
         enum:
-        - VERBINDLICHKEIT
-        - VERMOEGEN
+          - VERBINDLICHKEIT
+          - VERMOEGEN
       zahlungsTyp:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-        - AUSGABE
-        - EINNAHME
+          - AUSGABE
+          - EINNAHME
     title: Sparplaene
   Staat:
     type: object
@@ -3109,35 +3166,35 @@ definitions:
   StatusDTO:
     type: object
     required:
-    - antragsteller
-    - produktAnbieter
+      - antragsteller
+      - produktAnbieter
     properties:
       ablehnungsgrund:
         type: string
         enum:
-        - FINANZIELLE_SITUATION
-        - GEGENANGEBOT
-        - KEINE_ANGABE
-        - KRITERIEN
-        - NEGATIV_MERKMAL
-        - UNTERLAGEN_UNVOLLSTAENDIG
-        - WERTERMITTLUNG
+          - FINANZIELLE_SITUATION
+          - GEGENANGEBOT
+          - KEINE_ANGABE
+          - KRITERIEN
+          - NEGATIV_MERKMAL
+          - UNTERLAGEN_UNVOLLSTAENDIG
+          - WERTERMITTLUNG
       antragsteller:
         type: string
         enum:
-        - BEANTRAGT
-        - NICHT_ANGENOMMEN
-        - UNTERSCHRIEBEN
-        - WIDERRUFEN
+          - BEANTRAGT
+          - NICHT_ANGENOMMEN
+          - UNTERSCHRIEBEN
+          - WIDERRUFEN
       kommentar:
         type: string
       produktAnbieter:
         type: string
         enum:
-        - ABGELEHNT
-        - NICHT_BEARBEITET
-        - UNTERSCHRIEBEN
-        - ZURUECKGESTELLT
+          - ABGELEHNT
+          - NICHT_BEARBEITET
+          - UNTERSCHRIEBEN
+          - ZURUECKGESTELLT
     title: StatusDTO
   Tilgung:
     type: object
@@ -3182,52 +3239,59 @@ definitions:
   VariablesDarlehen:
     title: VariablesDarlehen
     allOf:
-    - $ref: '#/definitions/GegenangebotDarlehen'
-    - type: object
-      required:
-      - anfaenglicheTilgung
-      - darlehensBetrag
-      - darlehensTyp
-      - effektivZins
-      - laufzeitKalkulatorischInJahren
-      - rateMonatlich
-      - sollZins
-      - vertriebsProvisionGesamtAbsolut
-      discriminator: darlehensTyp
-      properties:
-        anfaenglicheTilgung:
-          type: number
-        bereitstellungsZins:
-          type: number
-        bereitstellungsZinsFreieZeitInMonaten:
-          type: integer
-          format: int32
-        darlehensBetrag:
-          type: number
-        darlehensTyp:
-          type: string
-          enum:
-          - VARIABLES_DARLEHEN
-        effektivZins:
-          type: number
-        laufzeitKalkulatorischInJahren:
-          type: integer
-          format: int32
-        produktDetails:
-          type: string
-          description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
-        rateMonatlich:
-          type: number
-        sollZins:
-          type: number
-        tilgungsBeginnAm:
-          type: string
-          format: date-time
-          example: 2020-03-28
-        vertriebsProvisionGesamtAbsolut:
-          type: number
-      title: VariablesDarlehen
-      description: Erweitert GegenangebotDarlehen
+      - $ref: '#/definitions/GegenangebotDarlehen'
+      - type: object
+        required:
+          - anfaenglicheTilgung
+          - darlehensBetrag
+          - darlehensTyp
+          - effektivZins
+          - laufzeitKalkulatorischInJahren
+          - rateMonatlich
+          - sollZins
+          - vertriebsProvisionGesamtAbsolut
+        discriminator: darlehensTyp
+        properties:
+          anfaenglicheTilgung:
+            type: number
+          bereitstellungsZins:
+            type: number
+          bereitstellungsZinsFreieZeitInMonaten:
+            type: integer
+            format: int32
+          darlehensBetrag:
+            type: number
+          darlehensTyp:
+            type: string
+            enum:
+              - ANNUITAETEN_DARLEHEN
+              - FORWARD_DARLEHEN
+              - KFW_DARLEHEN
+              - PRIVAT_DARLEHEN
+              - REGIONAL_FOERDER_DARLEHEN
+              - VARIABLES_DARLEHEN
+              - ZWISCHEN_FINANZIERUNG
+          effektivZins:
+            type: number
+          laufzeitKalkulatorischInJahren:
+            type: integer
+            format: int32
+          produktDetails:
+            type: string
+            description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
+          rateMonatlich:
+            type: number
+          sollZins:
+            type: number
+          tilgungsBeginnAm:
+            type: string
+            format: date-time
+            example: 2020-03-28
+          vertriebsProvisionGesamtAbsolut:
+            type: number
+            description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
+        title: VariablesDarlehen
+        description: Erweitert GegenangebotDarlehen
     description: Erweitert GegenangebotDarlehen
   Verbindlichkeit:
     type: object
@@ -3245,16 +3309,16 @@ definitions:
         type: string
         description: Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium
         enum:
-        - VERBINDLICHKEIT
-        - VERMOEGEN
+          - VERBINDLICHKEIT
+          - VERMOEGEN
       wirdAbgeloest:
         type: boolean
       zahlungsTyp:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-        - AUSGABE
-        - EINNAHME
+          - AUSGABE
+          - EINNAHME
     title: Verbindlichkeit
   VermietungsInformationen:
     type: object
@@ -3264,9 +3328,9 @@ definitions:
       nutzungsArt:
         type: string
         enum:
-        - EIGENGENUTZT
-        - TEIL_VERMIETET
-        - VERMIETET
+          - EIGENGENUTZT
+          - TEIL_VERMIETET
+          - VERMIETET
       vermieteteFlaeche:
         type: number
     title: VermietungsInformationen
@@ -3281,8 +3345,8 @@ definitions:
         type: string
         description: Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium
         enum:
-        - VERBINDLICHKEIT
-        - VERMOEGEN
+          - VERBINDLICHKEIT
+          - VERMOEGEN
     title: Vermoegen
   VermoegenVerbindlichkeit:
     type: object
@@ -3298,8 +3362,8 @@ definitions:
       vermoegensTyp:
         type: string
         enum:
-        - VERBINDLICHKEIT
-        - VERMOEGEN
+          - VERBINDLICHKEIT
+          - VERMOEGEN
     title: VermoegenVerbindlichkeit
   VermoegenVerbindlichkeiten:
     type: object
@@ -3350,12 +3414,12 @@ definitions:
       verwendungszweck:
         type: string
         enum:
-        - ANSCHLUSSFINANZIERUNG
-        - KAPITALBESCHAFFUNG
-        - KAUF
-        - KAUF_NEUBAU_VOM_BAUTRAEGER
-        - MODERNISIERUNG_UMBAU_ANBAU
-        - NEUBAU
+          - ANSCHLUSSFINANZIERUNG
+          - KAPITALBESCHAFFUNG
+          - KAUF
+          - KAUF_NEUBAU_VOM_BAUTRAEGER
+          - MODERNISIERUNG_UMBAU_ANBAU
+          - NEUBAU
     title: Vorhaben
   Wertpapiere:
     type: object
@@ -3370,14 +3434,14 @@ definitions:
         type: string
         description: Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium
         enum:
-        - VERBINDLICHKEIT
-        - VERMOEGEN
+          - VERBINDLICHKEIT
+          - VERMOEGEN
       zahlungsTyp:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-        - AUSGABE
-        - EINNAHME
+          - AUSGABE
+          - EINNAHME
     title: Wertpapiere
   Zahlungsplaene:
     type: object
@@ -3438,6 +3502,6 @@ definitions:
       typ:
         type: string
         enum:
-        - TILGUNGSPLAN
+          - TILGUNGSPLAN
     title: zahlungsplan
     description: Diese Resource repräsentiert einen Zahlungsplan.


### PR DESCRIPTION
Für ein bestehende Darlehens an einer Immobilien  liefern wir jetzt 3 neue Felder:

- wirdAbgeloest: true, wenn Darlehen abgelöst werden soll, sonst immer false
- restschuldAktuell: aktuelle Restschuld 
- restschuldZumAbloeseTermin: Restschuld zum Ablösetermin 

Die beiden Felder abzuloesendeRestschuld, aktuelleRestschuldWennNichtAbzuloesen behalten ihre bisherige Funktion, sind nun aber **deprecated** und sollten **nicht** mehr verwendet werden.

```json
{
    "finanzierungsObjekt": {
      "bestehendeDarlehen": [
        {
          "wirdAbgeloest": true,
          "restschuldAktuell": 20000.00,
          "restschuldZumAbloeseTermin": 20000.00
        }
      ]
    }
}
```