### PR TITLE
Release 2.35 - TarifId in Bausparvertrag des Angebots

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -590,7 +590,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="sect2">
 <h3 id="_aktuelle_version">Aktuelle Version</h3>
 <div class="paragraph">
-<p><em>Version</em> : 2.34</p>
+<p><em>Version</em> : 2.35</p>
 </div>
 </div>
 <div class="sect2">
@@ -5022,7 +5022,21 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p><strong>tarif</strong><br>
 <em>optional</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Tarifname</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>tarifId</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Produktanbieter-spezifische Tarif-ID des Bauspartarifs</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>string</p>
 </div></div></td>
@@ -5241,7 +5255,21 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p><strong>tarif</strong><br>
 <em>optional</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Tarifname</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>tarifId</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Produktanbieter-spezifische Tarif-ID des Bauspartarifs</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>string</p>
 </div></div></td>
@@ -6039,7 +6067,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p><strong>tarif</strong><br>
 <em>optional</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Tarifname</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>string</p>
 </div></div></td>
@@ -9574,7 +9604,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p><strong>tarif</strong><br>
 <em>optional</em></p>
 </div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Tarifname</p>
+</div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>string</p>
 </div></div></td>
@@ -12667,7 +12699,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-03-09 09:43:59 +0100
+Last updated 2021-03-29 14:09:54 +0200
 </div>
 </div>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5031,18 +5031,6 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </tr>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p><strong>tarifId</strong><br>
-<em>optional</em></p>
-</div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p>Produktanbieter-spezifische Tarif-ID des Bauspartarifs</p>
-</div></div></td>
-<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p>string</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>tilgungsPhase</strong><br>
 <em>optional</em></p>
 </div></div></td>
@@ -12699,7 +12687,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-03-29 14:09:54 +0200
+Last updated 2021-04-01 17:26:07 +0200
 </div>
 </div>
 </body>

--- a/swagger.json
+++ b/swagger.json
@@ -6,7 +6,7 @@
     "title": "Anträge API",
     "contact": {
       "name": "Europace AG",
-      "url": "www.europace2.de",
+      "url": "https://www.europace2.de",
       "email": "devsupport@europace2.de"
     }
   },
@@ -1750,10 +1750,6 @@
         "tarif": {
           "type": "string",
           "description": "Tarifname"
-        },
-        "tarifId": {
-          "type": "string",
-          "description": "Produktanbieter-spezifische Tarif-ID des Bauspartarifs"
         },
         "tilgungsPhase": {
           "$ref": "#/definitions/TilgungsPhase"

--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Kontext des Produktanbieters eingenommen.",
-    "version": "2.34",
+    "version": "2.35",
     "title": "Anträge API",
     "contact": {
       "name": "Europace AG",
@@ -1748,7 +1748,12 @@
           "$ref": "#/definitions/SparPhase"
         },
         "tarif": {
-          "type": "string"
+          "type": "string",
+          "description": "Tarifname"
+        },
+        "tarifId": {
+          "type": "string",
+          "description": "Produktanbieter-spezifische Tarif-ID des Bauspartarifs"
         },
         "tilgungsPhase": {
           "$ref": "#/definitions/TilgungsPhase"
@@ -1830,7 +1835,12 @@
           "$ref": "#/definitions/SparPhase"
         },
         "tarif": {
-          "type": "string"
+          "type": "string",
+          "description": "Tarifname"
+        },
+        "tarifId": {
+          "type": "string",
+          "description": "Produktanbieter-spezifische Tarif-ID des Bauspartarifs"
         },
         "tilgungsPhase": {
           "$ref": "#/definitions/TilgungsPhase"
@@ -2124,7 +2134,8 @@
           "type": "number"
         },
         "tarif": {
-          "type": "string"
+          "type": "string",
+          "description": "Tarifname"
         },
         "typ": {
           "type": "string"
@@ -3587,7 +3598,8 @@
           "type": "number"
         },
         "tarif": {
-          "type": "string"
+          "type": "string",
+          "description": "Tarifname"
         },
         "typ": {
           "type": "string",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6,7 +6,7 @@ info:
   title: Anträge API
   contact:
     name: Europace AG
-    url: www.europace2.de
+    url: https://www.europace2.de
     email: devsupport@europace2.de
 host: baufismart.api.europace.de
 basePath: /
@@ -1214,9 +1214,6 @@ definitions:
       tarif:
         type: string
         description: Tarifname
-      tarifId:
-        type: string
-        description: Produktanbieter-spezifische Tarif-ID des Bauspartarifs
       tilgungsPhase:
         $ref: '#/definitions/TilgungsPhase'
       typ:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2,7 +2,7 @@
 swagger: "2.0"
 info:
   description: Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Kontext des Produktanbieters eingenommen.
-  version: "2.34"
+  version: "2.35"
   title: Anträge API
   contact:
     name: Europace AG
@@ -1213,6 +1213,10 @@ definitions:
         $ref: '#/definitions/SparPhase'
       tarif:
         type: string
+        description: Tarifname
+      tarifId:
+        type: string
+        description: Produktanbieter-spezifische Tarif-ID des Bauspartarifs
       tilgungsPhase:
         $ref: '#/definitions/TilgungsPhase'
       typ:
@@ -1271,6 +1275,10 @@ definitions:
         $ref: '#/definitions/SparPhase'
       tarif:
         type: string
+        description: Tarifname
+      tarifId:
+        type: string
+        description: Produktanbieter-spezifische Tarif-ID des Bauspartarifs
       tilgungsPhase:
         $ref: '#/definitions/TilgungsPhase'
       typ:
@@ -1480,6 +1488,7 @@ definitions:
         type: number
       tarif:
         type: string
+        description: Tarifname
       typ:
         type: string
       vermoegensEinsatz:
@@ -2538,6 +2547,7 @@ definitions:
         type: number
       tarif:
         type: string
+        description: Tarifname
       typ:
         type: string
         enum:


### PR DESCRIPTION
Änderungen in Version 2.35

Es gibt ein neues Feld `tarifId` im `Bausparvertrag` (Teil des Angebots). Dieses enthält die produktanbieter-spezifische Tarif-ID des Bauspartarifs.

Beispiel Response:

```json
"angebot": {
  "bausparvertraege": [
    {
      "tarif": "BHW WohnBausparen (FI2N) 0,10% | 2,35%",
      "tarifId": "FI2N",
      "produktAnbieter": {
        "produktAnbieterId": "BHW",
        "produktAnbieterKurzName": "BHW Bausparkasse",
        // ...
      },
      // ...
    }
  ]
}
```

[Vorschau auf Index HTML der Version 2.35](https://htmlpreview.github.io/?https://github.com/europace/baufismart-antraege-api/blob/feature/release/2.35/docs/index.html)