### PR TITLE
PR automatisch erstellen

### DIFF
--- a/.github/workflows/pr_on_push.yml
+++ b/.github/workflows/pr_on_push.yml
@@ -1,0 +1,16 @@
+name: Pull Request on Branch Push
+on:
+  push:
+    branches:
+      - "publish/*"
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: pull-request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: ""                                 # If blank, default: triggered branch
+          destination_branch: "master"                      # If blank, default: master
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
Das Publishen der Dokudateien soll möglichst automatisch ablaufen. Aus diesem Grund ist angedacht, dass für Branches, die Dokudateien enthalten automatisch ein PR erstellt wird.
### Änderungen
Ein entsprechender GitHub Action Workflow wurde angelegt