### PR TITLE
Weitere Automatisierung des Doku Publishing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+### Motivation
+> Hier bitte kurz motivieren, warum es diese Codeanpassungen gibt. Dabei sollte auf den groben Scope eingegangen werden (z.B. im Zuge welcher Story der PR gestellt wird).
+
+### Änderungen
+> Zusammenfassung der fachlichen Änderungen
+> 
+> Bei Frontendanpassungen Screenshots hinzufügen, aus denen die Änderung ersichtlich wird.
+
+### Test
+> Wie können die Änderungen getestet werden?
+>
+> Auf welcher Ebene sind die Tests (siehe Testpyramide)
+
+

--- a/.github/workflows/pr_on_push.yml
+++ b/.github/workflows/pr_on_push.yml
@@ -8,9 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Expose git commit data
+        uses: rlespinasse/git-commit-data-action@v1.x
+      - name: Set Git commit committer name
+        run: echo "::set-output name=GIT_COMMIT_COMMITTER_NAME::${{ env.GIT_COMMIT_COMMITTER_NAME }}"
+        id: git-commit-committer-name-setter
       - name: pull-request
         uses: repo-sync/pull-request@v2
         with:
           source_branch: ""                                 # If blank, default: triggered branch
           destination_branch: "master"                      # If blank, default: master
+          pr_template: ".github/pull_request_template.md"
+          pr_assignee: ${{ steps.git-commit-committer-name-setter.outputs.GIT_COMMIT_COMMITTER_NAME}}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
MIt diesen Änderungen ist es möglich, dass der Assignee für einen automatisch erstellten PR automatisch gesetzt wird.
Zusätzlich kann ein Template als Basis für die Description eines PRs genutzt werden.

### Änderungen
- Steps zum GitHub-Action workflow hinzugefügt, die automatisch den Assignee für einen automatisch erstellten PR setzen
( dieser Assignee ist der Commiter, der auf dem Quellrepo die aktualisierte Doku gemerged hat ) 
- PR Template, welches als Basis für einen PR genommen wird, hinzugefügt.