### PR TITLE
Unnötigen step in GitHub Action entfernt

### DIFF
--- a/.github/workflows/pr_on_push.yml
+++ b/.github/workflows/pr_on_push.yml
@@ -10,14 +10,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Expose git commit data
         uses: rlespinasse/git-commit-data-action@v1.x
-      - name: Set Git commit committer name
-        run: echo "::set-output name=GIT_COMMIT_COMMITTER_NAME::${{ env.GIT_COMMIT_COMMITTER_NAME }}"
-        id: git-commit-committer-name-setter
       - name: pull-request
         uses: repo-sync/pull-request@v2
         with:
           source_branch: ""                                 # If blank, default: triggered branch
           destination_branch: "master"                      # If blank, default: master
           pr_template: ".github/pull_request_template.md"
-          pr_assignee: ${{ steps.git-commit-committer-name-setter.outputs.GIT_COMMIT_COMMITTER_NAME}}
+          pr_assignee: ${{ env.GIT_COMMIT_COMMITTER_NAME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
Unnötige Steps bzw. unnötiger Code sollte vermieden werden. Das Erstellen eines separaten Steps, um den gewünschten Wert in einer Variable verfügbar zu machen, ist nicht notwendig, da dies bereits passiert. Aus diesem Grund soll der Step entfernt werden.

### Änderungen
- unnötigen Step entfernt

### Test
keine


