### PR TITLE
[MTV-570] Markierung des aktiven Antrags an einem Vorgang

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.10">
+<meta name="generator" content="Asciidoctor 2.0.15">
 <title>Anträge API</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
@@ -47,7 +47,7 @@ textarea{overflow:auto;vertical-align:top}
 table{border-collapse:collapse;border-spacing:0}
 *,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
 html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
 a:hover{cursor:pointer}
 img,object,embed{max-width:100%;height:auto}
 object,embed{height:100%}
@@ -62,10 +62,8 @@ img{-ms-interpolation-mode:bicubic}
 img,object,svg{display:inline-block;vertical-align:middle}
 textarea{height:auto;min-height:50px}
 select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
 .subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
 a{color:#2156a5;text-decoration:underline;line-height:inherit}
 a:hover,a:focus{color:#1d4b8f}
 a img{border:0}
@@ -96,28 +94,28 @@ dl dd{margin-bottom:1.25em}
 abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
 abbr{text-transform:none}
 blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
-blockquote cite::before{content:"\2014 \0020"}
-blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
 blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
 @media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
 h1{font-size:2.75em}
 h2{font-size:2.3125em}
 h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
 h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede;word-wrap:normal}
 table thead,table tfoot{background:#f7f8f7}
 table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
 table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
 table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
 h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
 h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
 .clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
 .clearfix::after,.float-group::after{clear:both}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-:not(pre)>code.nobreak{word-wrap:normal}
-:not(pre)>code.nowrap{white-space:nowrap}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
 pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
 pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
 pre>code{display:block}
@@ -182,7 +180,7 @@ body.toc2.toc-right{padding-left:0;padding-right:20em}}
 #content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
 #content #toc>:first-child{margin-top:0}
 #content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
 #footer-text{color:rgba(255,255,255,.8);line-height:1.44}
 #content{margin-bottom:.625em}
 .sect1{padding-bottom:.625em}
@@ -205,7 +203,7 @@ table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font
 .admonitionblock>table td.icon{text-align:center;width:80px}
 .admonitionblock>table td.icon img{max-width:none}
 .admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
 .admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
 .exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
 .exampleblock>.content>:first-child{margin-top:0}
@@ -215,7 +213,7 @@ table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font
 .sidebarblock>:last-child{margin-bottom:0}
 .sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
 .exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
 @media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
 @media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
 .literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
@@ -260,22 +258,21 @@ pre.pygments .lineno::before{content:"";margin-right:-.125em}
 .quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
 .quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
 .quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
-table.tableblock{max-width:100%;border-collapse:separate}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
 p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
 td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
 table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
-table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
-table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
-table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
-table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
-table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
-table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
 table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
 table.frame-sides{border-width:0 1px}
-table.frame-topbot,table.frame-ends{border-width:1px 0}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
 table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
 th.halign-left,td.halign-left{text-align:left}
 th.halign-right,td.halign-right{text-align:right}
@@ -284,7 +281,7 @@ th.valign-top,td.valign-top{vertical-align:top}
 th.valign-bottom,td.valign-bottom{vertical-align:bottom}
 th.valign-middle,td.valign-middle{vertical-align:middle}
 table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th{background:#f7f8f7}
 tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
 p.tableblock>code:only-child{background:none;padding:0}
 p.tableblock{font-size:1em}
@@ -313,6 +310,7 @@ ol.lowergreek{list-style-type:lower-greek}
 .hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
 td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
 td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
 .literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
 .colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
 .colist td:not([class]):first-child img{max-width:none}
@@ -385,7 +383,7 @@ a span.icon>.fa{cursor:inherit}
 .admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
 .admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
 .admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:50%;border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
 .conum[data-value] *{color:#fff!important}
 .conum[data-value]+b{display:none}
 .conum[data-value]::after{content:attr(data-value)}
@@ -412,6 +410,7 @@ thead{display:table-header-group}
 svg{max-width:100%}
 p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
 h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
 #toc,.sidebarblock,.exampleblock>.content{background:none!important}
 #toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
 body.book #header{text-align:center}
@@ -590,7 +589,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="sect2">
 <h3 id="_aktuelle_version">Aktuelle Version</h3>
 <div class="paragraph">
-<p><em>Version</em> : 2.39</p>
+<p><em>Version</em> : 2.40</p>
 </div>
 </div>
 <div class="sect2">
@@ -795,106 +794,52 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <td class="tableblock halign-left valign-middle"><div class="content"></div></td>
 </tr>
 <tr>
-    <td class="tableblock halign-left valign-middle">
-        <div class="content">
-            <div class="paragraph">
-                <p><strong>Query</strong></p>
-            </div>
-        </div>
-    </td>
-    <td class="tableblock halign-left valign-middle">
-        <div class="content">
-            <div class="paragraph">
-                <p><strong>angenommenNach</strong><br>
-                    <em>optional</em></p>
-            </div>
-        </div>
-    </td>
-    <td class="tableblock halign-left valign-middle">
-        <div class="content">
-            <div class="paragraph">
-                <p>Datum im ISO Format UTC - Zulu</p>
-            </div>
-        </div>
-    </td>
-    <td class="tableblock halign-left valign-middle">
-        <div class="content">
-            <div class="paragraph">
-                <p>string</p>
-            </div>
-        </div>
-    </td>
-    <td class="tableblock halign-left valign-middle">
-        <div class="content"></div>
-    </td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Query</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>angenommenNach</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Datum im ISO Format UTC - Zulu</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
 </tr>
 <tr>
-    <td class="tableblock halign-left valign-middle">
-        <div class="content">
-            <div class="paragraph">
-                <p><strong>Query</strong></p>
-            </div>
-        </div>
-    </td>
-    <td class="tableblock halign-left valign-middle">
-        <div class="content">
-            <div class="paragraph">
-                <p><strong>angenommenVor</strong><br>
-                    <em>optional</em></p>
-            </div>
-        </div>
-    </td>
-    <td class="tableblock halign-left valign-middle">
-        <div class="content">
-            <div class="paragraph">
-                <p>Datum im ISO Format UTC - Zulu. Setzen des Parameters erzwingt das Zulu Datumsformat für beide 'angenommen' Parameter.</p>
-            </div>
-        </div>
-    </td>
-    <td class="tableblock halign-left valign-middle">
-        <div class="content">
-            <div class="paragraph">
-                <p>string</p>
-            </div>
-        </div>
-    </td>
-    <td class="tableblock halign-left valign-middle">
-        <div class="content"></div>
-    </td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Query</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>angenommenVor</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Datum im ISO Format UTC - Zulu. Setzen des Parameters erzwingt das Zulu Datumsformat für beide 'angenommen' Parameter.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
 </tr>
 <tr>
-    <td class="tableblock halign-left valign-middle">
-        <div class="content">
-            <div class="paragraph">
-                <p><strong>Query</strong></p>
-            </div>
-        </div>
-    </td>
-    <td class="tableblock halign-left valign-middle">
-        <div class="content">
-            <div class="paragraph">
-                <p><strong>antragsReferenz</strong><br>
-                    <em>optional</em></p>
-            </div>
-        </div>
-    </td>
-    <td class="tableblock halign-left valign-middle">
-        <div class="content">
-            <div class="paragraph">
-                <p>Suche nach deiner antragsReferenz</p>
-            </div>
-        </div>
-    </td>
-    <td class="tableblock halign-left valign-middle">
-        <div class="content">
-            <div class="paragraph">
-                <p>string</p>
-            </div>
-        </div>
-    </td>
-    <td class="tableblock halign-left valign-middle">
-        <div class="content"></div>
-    </td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Query</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>antragsReferenz</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Suche nach deiner antragsReferenz</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
@@ -3971,6 +3916,18 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <td class="tableblock halign-left valign-middle"><div class="content"></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><a href="#_links">Links</a></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>aktiverAntrag</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Ein Produktanbieter kann nur einen aktiven Antrag an einem Vorgang haben. Dieses Feld zeigt an, welcher Antrag aktiv ist.Durch Statuswechsel wird diese Information verändert</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>boolean</p>
 </div></div></td>
 </tr>
 <tr>
@@ -7184,7 +7141,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <em>optional</em></p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-    <p>nur bei darlehensTyp==REGIONAL_FOERDER_DARLEHEN. Mögliche Werte: L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, L_BANK_WOHNEN_MIT_ZUKUNFT, NRW_BANK_WOHNEIGENTUM. Seit dem 01.07.21 bietet die L-Bank L_BANK_WOHNEN_MIT_ZUKUNFT nicht mehr als Programm an. Bei neu aufgelegten Programmen bzw. Aufnahme weiterer regionaler Förderbanken in die Plattform können weitere Werte zulässig werden.</p>
+<p>nur bei darlehensTyp==REGIONAL_FOERDER_DARLEHEN. Mögliche Werte: L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, L_BANK_WOHNEN_MIT_ZUKUNFT, NRW_BANK_WOHNEIGENTUM. Seit dem 01.07.21 bietet die L-Bank L_BANK_WOHNEN_MIT_ZUKUNFT nicht mehr als Programm an. Bei neu aufgelegten Programmen bzw. Aufnahme weiterer regionaler Förderbanken in die Plattform können weitere Werte zulässig werden.</p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p>string</p>
@@ -11319,7 +11276,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-    <p>enum (L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, NRW_BANK_WOHNEIGENTUM)</p>
+<p>enum (L_BANK_KOMBI_DARLEHEN_WOHNEN, L_BANK_WOHNEN_MIT_KIND, NRW_BANK_WOHNEIGENTUM)</p>
 </div></div></td>
 </tr>
 <tr>
@@ -12818,7 +12775,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div id="footer">
 <div id="footer-text">
-    Last updated 2021-07-19 16:44:46 +0200
+Last updated 2021-09-07 11:51:14 +0200
 </div>
 </div>
 </body>

--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Kontext des Produktanbieters eingenommen.",
-    "version": "2.39",
+    "version": "2.40",
     "title": "Anträge API",
     "contact": {
       "name": "Europace AG",
@@ -18,15 +18,21 @@
       "description": "Zugriff auf Anträge für die Kreditentscheidung"
     }
   ],
-  "schemes": ["https"],
+  "schemes": [
+    "https"
+  ],
   "paths": {
     "/v2/antraege": {
       "get": {
-        "tags": ["Antraege"],
+        "tags": [
+          "Antraege"
+        ],
         "summary": "Alle Anträge abrufen",
         "description": "Es werden alle Anträge ausgeliefert, die der authentifizierten Partner sehen darf. Offen: Sortierung, Pagination, Filterung",
         "operationId": "getAlleAntraege",
-        "produces": ["application/json;charset=UTF-8"],
+        "produces": [
+          "application/json;charset=UTF-8"
+        ],
         "parameters": [
           {
             "name": "aenderungBis",
@@ -74,7 +80,10 @@
             "required": false,
             "type": "string",
             "default": "ECHT_GESCHAEFT",
-            "enum": ["ECHT_GESCHAEFT", "TEST_MODUS"]
+            "enum": [
+              "ECHT_GESCHAEFT",
+              "TEST_MODUS"
+            ]
           },
           {
             "name": "limit",
@@ -162,18 +171,24 @@
         },
         "security": [
           {
-            "OAuth2": ["baufinanzierung:antrag:lesen"]
+            "OAuth2": [
+              "baufinanzierung:antrag:lesen"
+            ]
           }
         ]
       }
     },
     "/v2/antraege/{vorgang}": {
       "get": {
-        "tags": ["Antraege"],
+        "tags": [
+          "Antraege"
+        ],
         "summary": "Alle Anträge eines Vorgangs abrufen",
         "description": "Als Parameter wird die Vorgangsnummer in der Form 'AB1234' verwendet.",
         "operationId": "getAntraegeByVorgangNummer",
-        "produces": ["application/json;charset=UTF-8"],
+        "produces": [
+          "application/json;charset=UTF-8"
+        ],
         "parameters": [
           {
             "name": "vorgang",
@@ -236,18 +251,24 @@
         },
         "security": [
           {
-            "OAuth2": ["baufinanzierung:antrag:lesen"]
+            "OAuth2": [
+              "baufinanzierung:antrag:lesen"
+            ]
           }
         ]
       }
     },
     "/v2/antraege/{vorgang}/{antrag}": {
       "get": {
-        "tags": ["Antraege"],
+        "tags": [
+          "Antraege"
+        ],
         "summary": "Teilanträge eines Antrags abrufen",
         "description": "Als Parameter wird die Vorgangs- und Antragsnummer in der Form 'AB1234/1' verwendet.",
         "operationId": "getAntrag",
-        "produces": ["application/json;charset=UTF-8"],
+        "produces": [
+          "application/json;charset=UTF-8"
+        ],
         "parameters": [
           {
             "name": "antrag",
@@ -318,18 +339,24 @@
         },
         "security": [
           {
-            "OAuth2": ["baufinanzierung:antrag:lesen"]
+            "OAuth2": [
+              "baufinanzierung:antrag:lesen"
+            ]
           }
         ]
       }
     },
     "/v2/antraege/{vorgang}/{antrag}/{teilantrag}": {
       "get": {
-        "tags": ["Antraege"],
+        "tags": [
+          "Antraege"
+        ],
         "summary": "Einzelnen Antrag abrufen",
         "description": "Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.",
         "operationId": "getAntrag_1",
-        "produces": ["application/json;charset=UTF-8"],
+        "produces": [
+          "application/json;charset=UTF-8"
+        ],
         "parameters": [
           {
             "name": "antrag",
@@ -408,17 +435,26 @@
         },
         "security": [
           {
-            "OAuth2": ["baufinanzierung:antrag:lesen"]
+            "OAuth2": [
+              "baufinanzierung:antrag:lesen"
+            ]
           }
         ]
       },
       "patch": {
-        "tags": ["Antraege"],
+        "tags": [
+          "Antraege"
+        ],
         "summary": "Antrag aktualisieren",
         "description": "Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet. Es können mehrere Operationen gleichzeitig übertragen werden.",
         "operationId": "updateAntrag",
-        "consumes": ["application/json-patch+json", "application/json"],
-        "produces": ["*/*"],
+        "consumes": [
+          "application/json-patch+json",
+          "application/json"
+        ],
+        "produces": [
+          "*/*"
+        ],
         "parameters": [
           {
             "name": "antrag",
@@ -488,18 +524,24 @@
         },
         "security": [
           {
-            "OAuth2": ["baufinanzierung:antrag:schreiben"]
+            "OAuth2": [
+              "baufinanzierung:antrag:schreiben"
+            ]
           }
         ]
       }
     },
     "/v2/antraege/{vorgang}/{antrag}/{teilantrag}/angebot": {
       "get": {
-        "tags": ["Antraege"],
+        "tags": [
+          "Antraege"
+        ],
         "summary": "Angebot des Antrags abrufen",
         "description": "Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat.",
         "operationId": "getAngebot",
-        "produces": ["application/json;charset=UTF-8"],
+        "produces": [
+          "application/json;charset=UTF-8"
+        ],
         "parameters": [
           {
             "name": "antrag",
@@ -578,18 +620,24 @@
         },
         "security": [
           {
-            "OAuth2": ["baufinanzierung:antrag:lesen"]
+            "OAuth2": [
+              "baufinanzierung:antrag:lesen"
+            ]
           }
         ]
       }
     },
     "/v2/antraege/{vorgang}/{antrag}/{teilantrag}/angebot/zahlungsplaene": {
       "get": {
-        "tags": ["Antraege"],
+        "tags": [
+          "Antraege"
+        ],
         "summary": "Die Zahlungsplaene (Tilgungs- & Sparpläne) des angenommenen Angebots.",
         "description": "Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.",
         "operationId": "getZahlungsplaene",
-        "produces": ["application/json;charset=UTF-8"],
+        "produces": [
+          "application/json;charset=UTF-8"
+        ],
         "parameters": [
           {
             "name": "antrag",
@@ -670,18 +718,24 @@
         },
         "security": [
           {
-            "OAuth2": ["baufinanzierung:antrag:lesen"]
+            "OAuth2": [
+              "baufinanzierung:antrag:lesen"
+            ]
           }
         ]
       }
     },
     "/v2/antraege/{vorgang}/{antrag}/{teilantrag}/ansprechpartner": {
       "get": {
-        "tags": ["Antraege"],
+        "tags": [
+          "Antraege"
+        ],
         "summary": "Den Ansprechpartner (Vertrieb) des  Teilantrags abrufen.",
         "description": "Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.",
         "operationId": "getAnsprechpartner",
-        "produces": ["application/json;charset=UTF-8"],
+        "produces": [
+          "application/json;charset=UTF-8"
+        ],
         "parameters": [
           {
             "name": "antrag",
@@ -760,19 +814,27 @@
         },
         "security": [
           {
-            "OAuth2": ["baufinanzierung:antrag:lesen"]
+            "OAuth2": [
+              "baufinanzierung:antrag:lesen"
+            ]
           }
         ]
       }
     },
     "/v2/antraege/{vorgang}/{antrag}/{teilantrag}/gegenangebot": {
       "post": {
-        "tags": ["Antraege"],
+        "tags": [
+          "Antraege"
+        ],
         "summary": "Ein Gegenangebot erstellen",
         "description": "Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet. Das übergebene Angebot wird sofort als Gegenangebot gestellt. Der alte Antrag wird abgelehnt.",
         "operationId": "erstelleGegenangebot",
-        "consumes": ["application/json"],
-        "produces": ["application/json"],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "name": "antrag",
@@ -851,18 +913,27 @@
         },
         "security": [
           {
-            "OAuth2": ["baufinanzierung:antrag:schreiben", "baufinanzierung:echtgeschaeft"]
+            "OAuth2": [
+              "baufinanzierung:antrag:schreiben",
+              "baufinanzierung:echtgeschaeft"
+            ]
           }
         ]
       }
     },
     "/v2/antraege/{vorgang}/{antrag}/{teilantrag}/status": {
       "post": {
-        "tags": ["Antraege"],
+        "tags": [
+          "Antraege"
+        ],
         "summary": "Setzen des Antragsstatus",
         "operationId": "setAntragsStatus_1",
-        "consumes": ["application/json"],
-        "produces": ["application/json;charset=UTF-8"],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json;charset=UTF-8"
+        ],
         "parameters": [
           {
             "name": "antrag",
@@ -934,7 +1005,9 @@
         },
         "security": [
           {
-            "OAuth2": ["baufinanzierung:antrag:schreiben"]
+            "OAuth2": [
+              "baufinanzierung:antrag:schreiben"
+            ]
           }
         ]
       }
@@ -975,7 +1048,13 @@
         },
         "praemienZahlungsweise": {
           "type": "string",
-          "enum": ["EINMALIG", "HALBJAEHRLICH", "JAEHRLICH", "MONATLICH", "VIERTELJAEHRLICH"]
+          "enum": [
+            "EINMALIG",
+            "HALBJAEHRLICH",
+            "JAEHRLICH",
+            "MONATLICH",
+            "VIERTELJAEHRLICH"
+          ]
         },
         "tarifBezeichnung": {
           "type": "string"
@@ -1030,7 +1109,10 @@
         },
         "bewertungDesAngebots": {
           "type": "string",
-          "enum": ["ANGEBOT_ENTSPRICHT_DEM_WUNSCH_DES_KUNDEN", "ANGEBOT_ENTSPRICHT_DER_EMPFEHLUNG_DES_KUNDENBETREUERS"]
+          "enum": [
+            "ANGEBOT_ENTSPRICHT_DEM_WUNSCH_DES_KUNDEN",
+            "ANGEBOT_ENTSPRICHT_DER_EMPFEHLUNG_DES_KUNDENBETREUERS"
+          ]
         },
         "bonitaet": {
           "type": "array",
@@ -1054,7 +1136,11 @@
         },
         "machbarkeitsStatus": {
           "type": "string",
-          "enum": ["MACHBAR", "NICHT_MACHBAR", "UNTER_VORBEHALT_PRODUZENT"]
+          "enum": [
+            "MACHBAR",
+            "NICHT_MACHBAR",
+            "UNTER_VORBEHALT_PRODUZENT"
+          ]
         },
         "meldungen": {
           "type": "array",
@@ -1214,6 +1300,10 @@
         "_links": {
           "$ref": "#/definitions/Links"
         },
+        "aktiverAntrag": {
+          "type": "boolean",
+          "description": "Ein Produktanbieter kann nur einen aktiven Antrag an einem Vorgang haben. Dieses Feld zeigt an, welcher Antrag aktiv ist.Durch Statuswechsel wird diese Information verändert"
+        },
         "angebot": {
           "description": "Das angenommene Angebot, auf dem dieser Antrag basiert",
           "$ref": "#/definitions/AngebotZumAntrag"
@@ -1237,7 +1327,10 @@
         "datenKontext": {
           "type": "string",
           "description": "Gibt an, ob es sich um einen Antrag aus dem Testmodus oder Echtgeschäft handelt",
-          "enum": ["ECHT_GESCHAEFT", "TEST_MODUS"]
+          "enum": [
+            "ECHT_GESCHAEFT",
+            "TEST_MODUS"
+          ]
         },
         "dokumente": {
           "type": "array",
@@ -1315,7 +1408,12 @@
         "antragsteller": {
           "type": "string",
           "description": "Willenserklärung des Antragstellers",
-          "enum": ["BEANTRAGT", "NICHT_ANGENOMMEN", "UNTERSCHRIEBEN", "WIDERRUFEN"]
+          "enum": [
+            "BEANTRAGT",
+            "NICHT_ANGENOMMEN",
+            "UNTERSCHRIEBEN",
+            "WIDERRUFEN"
+          ]
         },
         "bearbeitungsFortschritt": {
           "type": "string",
@@ -1331,7 +1429,12 @@
         "produktAnbieter": {
           "type": "string",
           "description": "Willenserklärung des Produktanbieters",
-          "enum": ["ABGELEHNT", "NICHT_BEARBEITET", "UNTERSCHRIEBEN", "ZURUECKGESTELLT"]
+          "enum": [
+            "ABGELEHNT",
+            "NICHT_BEARBEITET",
+            "UNTERSCHRIEBEN",
+            "ZURUECKGESTELLT"
+          ]
         }
       },
       "title": "AntragsStatus"
@@ -1344,7 +1447,10 @@
         },
         "anrede": {
           "type": "string",
-          "enum": ["FRAU", "HERR"]
+          "enum": [
+            "FRAU",
+            "HERR"
+          ]
         },
         "anschrift": {
           "$ref": "#/definitions/Postadresse"
@@ -1361,7 +1467,12 @@
         "aufenthaltsTitel": {
           "type": "string",
           "description": "wenn der Antragssteller die Staatsangehörigkeit eines Nicht-EU-Landes hat",
-          "enum": ["AUFENTHALTS_ERLAUBNIS", "DAUERAUFENTHALT_EU", "NIEDERLASSUNGS_ERLAUBNIS", "VISUM"]
+          "enum": [
+            "AUFENTHALTS_ERLAUBNIS",
+            "DAUERAUFENTHALT_EU",
+            "NIEDERLASSUNGS_ERLAUBNIS",
+            "VISUM"
+          ]
         },
         "aufenthaltsTitelBefristetBis": {
           "type": "string",
@@ -1411,7 +1522,14 @@
         },
         "familienstand": {
           "type": "string",
-          "enum": ["GESCHIEDEN", "GETRENNT_LEBEND", "LEBENSPARTNERSCHAFT", "LEDIG", "VERHEIRATET", "VERWITWET"]
+          "enum": [
+            "GESCHIEDEN",
+            "GETRENNT_LEBEND",
+            "LEBENSPARTNERSCHAFT",
+            "LEDIG",
+            "VERHEIRATET",
+            "VERWITWET"
+          ]
         },
         "geburtsdatum": {
           "type": "string",
@@ -1506,7 +1624,10 @@
         "zahlungsTyp": {
           "type": "string",
           "description": "Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium",
-          "enum": ["AUSGABE", "EINNAHME"]
+          "enum": [
+            "AUSGABE",
+            "EINNAHME"
+          ]
         }
       },
       "title": "AusgabenMonatlich"
@@ -1519,7 +1640,14 @@
         },
         "typ": {
           "type": "string",
-          "enum": ["CARPORT", "DOPPEL_GARAGE", "GARAGE", "KELLER_GARAGE", "STELLPLATZ", "TIEFGARAGEN_STELLPLATZ"]
+          "enum": [
+            "CARPORT",
+            "DOPPEL_GARAGE",
+            "GARAGE",
+            "KELLER_GARAGE",
+            "STELLPLATZ",
+            "TIEFGARAGEN_STELLPLATZ"
+          ]
         }
       },
       "title": "Autostellplatz"
@@ -1536,12 +1664,18 @@
         "vermoegensTyp": {
           "type": "string",
           "description": "Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium",
-          "enum": ["VERBINDLICHKEIT", "VERMOEGEN"]
+          "enum": [
+            "VERBINDLICHKEIT",
+            "VERMOEGEN"
+          ]
         },
         "zahlungsTyp": {
           "type": "string",
           "description": "Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium",
-          "enum": ["AUSGABE", "EINNAHME"]
+          "enum": [
+            "AUSGABE",
+            "EINNAHME"
+          ]
         },
         "zinsertragJaehrlich": {
           "type": "number"
@@ -1585,7 +1719,10 @@
         "abschlussGebuehrenVerrechnung": {
           "type": "string",
           "description": "Erlaubte Werte sind: SOFORTZAHLUNG, VERRECHNUNG",
-          "enum": ["SOFORTZAHLUNG", "VERRECHNUNG"]
+          "enum": [
+            "SOFORTZAHLUNG",
+            "VERRECHNUNG"
+          ]
         },
         "angebotsHinweisFuerAntragsteller": {
           "type": "string",
@@ -1665,7 +1802,10 @@
         "abschlussGebuehrenVerrechnung": {
           "type": "string",
           "description": "Erlaubte Werte sind: SOFORTZAHLUNG, VERRECHNUNG",
-          "enum": ["SOFORTZAHLUNG", "VERRECHNUNG"]
+          "enum": [
+            "SOFORTZAHLUNG",
+            "VERRECHNUNG"
+          ]
         },
         "angebotsHinweisFuerAntragsteller": {
           "type": "string",
@@ -1784,7 +1924,11 @@
       "properties": {
         "art": {
           "type": "string",
-          "enum": ["AUSSER_GESCHAEFTSRAUM_VERTRAG", "FERN_ABSATZ_GESCHAEFT", "PRAESENZ_GESCHAEFT"]
+          "enum": [
+            "AUSSER_GESCHAEFTSRAUM_VERTRAG",
+            "FERN_ABSATZ_GESCHAEFT",
+            "PRAESENZ_GESCHAEFT"
+          ]
         },
         "hinweisFuerProduktAnbieter": {
           "type": "string"
@@ -1832,7 +1976,10 @@
         "befristungsStatus": {
           "type": "string",
           "description": "nur bei art==ANGESTELLTER,ARBEITER",
-          "enum": ["BEFRISTET", "UNBEFRISTET"]
+          "enum": [
+            "BEFRISTET",
+            "UNBEFRISTET"
+          ]
         },
         "beruf": {
           "type": "string",
@@ -1913,7 +2060,11 @@
         },
         "immobilienEinsatz": {
           "type": "string",
-          "enum": ["ALS_ZUSATZSICHERHEIT", "KEIN_EINSATZ", "VERKAUFEN"]
+          "enum": [
+            "ALS_ZUSATZSICHERHEIT",
+            "KEIN_EINSATZ",
+            "VERKAUFEN"
+          ]
         },
         "keinBaulandFlaecheInQm": {
           "type": "number",
@@ -1928,7 +2079,11 @@
         },
         "objektArt": {
           "type": "string",
-          "enum": ["EIGENTUMSWOHNUNG", "GRUNDSTUECK", "HAUS"]
+          "enum": [
+            "EIGENTUMSWOHNUNG",
+            "GRUNDSTUECK",
+            "HAUS"
+          ]
         },
         "vergleichsmieteFuerGewerbeflaecheProQm": {
           "type": "number",
@@ -1995,12 +2150,19 @@
         },
         "vermoegensEinsatz": {
           "type": "string",
-          "enum": ["ABTRETEN", "AUFLOESEN", "KEIN_EINSATZ"]
+          "enum": [
+            "ABTRETEN",
+            "AUFLOESEN",
+            "KEIN_EINSATZ"
+          ]
         },
         "vermoegensTyp": {
           "type": "string",
           "description": "Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium",
-          "enum": ["VERBINDLICHKEIT", "VERMOEGEN"]
+          "enum": [
+            "VERBINDLICHKEIT",
+            "VERMOEGEN"
+          ]
         },
         "vertragsBeginn": {
           "type": "string",
@@ -2015,7 +2177,10 @@
         "zahlungsTyp": {
           "type": "string",
           "description": "Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium",
-          "enum": ["AUSGABE", "EINNAHME"]
+          "enum": [
+            "AUSGABE",
+            "EINNAHME"
+          ]
         },
         "zuteilungsDatum": {
           "type": "string",
@@ -2041,7 +2206,13 @@
         "darlehensArt": {
           "type": "string",
           "description": "Erlaubte Werte sind: BAUSPARDARLEHEN,FOERDERDARLEHEN,IMMOBILIENDARLEHEN,PRIVATDARLEHEN,SONSTIGES_DARLEHEN. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.",
-          "enum": ["BAUSPARDARLEHEN", "FOERDERDARLEHEN", "IMMOBILIENDARLEHEN", "PRIVATDARLEHEN", "SONSTIGES_DARLEHEN"]
+          "enum": [
+            "BAUSPARDARLEHEN",
+            "FOERDERDARLEHEN",
+            "IMMOBILIENDARLEHEN",
+            "PRIVATDARLEHEN",
+            "SONSTIGES_DARLEHEN"
+          ]
         },
         "darlehensBetrag": {
           "type": "number",
@@ -2060,7 +2231,10 @@
         "grundschuldArt": {
           "type": "string",
           "description": "Erlaubte Werte sind: BUCH_GRUNDSCHULD, BRIEF_GRUNDSCHULD. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.",
-          "enum": ["BRIEF_GRUNDSCHULD", "BUCH_GRUNDSCHULD"]
+          "enum": [
+            "BRIEF_GRUNDSCHULD",
+            "BUCH_GRUNDSCHULD"
+          ]
         },
         "hauptKontonummerDslBank": {
           "type": "string",
@@ -2119,7 +2293,13 @@
         "darlehensArt": {
           "type": "string",
           "description": "Erlaubte Werte sind: BAUSPARDARLEHEN,FOERDERDARLEHEN,IMMOBILIENDARLEHEN,PRIVATDARLEHEN,SONSTIGES_DARLEHEN. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.",
-          "enum": ["BAUSPARDARLEHEN", "FOERDERDARLEHEN", "IMMOBILIENDARLEHEN", "PRIVATDARLEHEN", "SONSTIGES_DARLEHEN"]
+          "enum": [
+            "BAUSPARDARLEHEN",
+            "FOERDERDARLEHEN",
+            "IMMOBILIENDARLEHEN",
+            "PRIVATDARLEHEN",
+            "SONSTIGES_DARLEHEN"
+          ]
         },
         "darlehensBetrag": {
           "type": "number",
@@ -2138,7 +2318,10 @@
         "grundschuldArt": {
           "type": "string",
           "description": "Erlaubte Werte sind: BUCH_GRUNDSCHULD, BRIEF_GRUNDSCHULD. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.",
-          "enum": ["BRIEF_GRUNDSCHULD", "BUCH_GRUNDSCHULD"]
+          "enum": [
+            "BRIEF_GRUNDSCHULD",
+            "BUCH_GRUNDSCHULD"
+          ]
         },
         "hauptKontonummerDslBank": {
           "type": "string",
@@ -2172,7 +2355,11 @@
         "verwendenAls": {
           "type": "string",
           "description": "Beschreibt wie das Darlehen im Zusammenhang mit dem Vorhaben, behandelt werden soll.",
-          "enum": ["ABLOESEN", "TRITT_IM_RANG_ZURUECK", "TRITT_NICHT_IM_RANG_ZURUECK"]
+          "enum": [
+            "ABLOESEN",
+            "TRITT_IM_RANG_ZURUECK",
+            "TRITT_NICHT_IM_RANG_ZURUECK"
+          ]
         },
         "wirdAbgeloest": {
           "type": "boolean",
@@ -2227,7 +2414,11 @@
       "properties": {
         "typ": {
           "type": "string",
-          "enum": ["ING", "MHB", "S_RATING"]
+          "enum": [
+            "ING",
+            "MHB",
+            "S_RATING"
+          ]
         },
         "wert": {
           "type": "string",
@@ -2377,7 +2568,11 @@
         "verwendungsZweck": {
           "type": "string",
           "description": "nur bei darlehensTyp==ZWISCHEN_FINANZIERUNG",
-          "enum": ["SONSTIGE_VERWENDUNG", "VERKAUF_EINES_ANDEREN_OBJEKTS", "VORFINANZIERUNG_OEFFENTLICHER_MITTEL"]
+          "enum": [
+            "SONSTIGE_VERWENDUNG",
+            "VERKAUF_EINES_ANDEREN_OBJEKTS",
+            "VORFINANZIERUNG_OEFFENTLICHER_MITTEL"
+          ]
         },
         "zinsBindung": {
           "description": "nicht bei darlehensTyp IN [VARIABLES_DARLEHEN,ZWISCHEN_FINANZIERUNG]",
@@ -2459,7 +2654,10 @@
         "zahlungsTyp": {
           "type": "string",
           "description": "Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium",
-          "enum": ["AUSGABE", "EINNAHME"]
+          "enum": [
+            "AUSGABE",
+            "EINNAHME"
+          ]
         }
       },
       "title": "EinkuenfteAusNebentaetigkeit"
@@ -2473,7 +2671,10 @@
         "zahlungsTyp": {
           "type": "string",
           "description": "Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium",
-          "enum": ["AUSGABE", "EINNAHME"]
+          "enum": [
+            "AUSGABE",
+            "EINNAHME"
+          ]
         }
       },
       "title": "EinnahmenMonatlich"
@@ -2505,14 +2706,21 @@
         },
         "typ": {
           "type": "string",
-          "enum": ["AGGREGIERTER_EINTRAG", "EINTRAG", "SUMMEN_EINTRAG_ZUM_ZINSBINDUNGSENDE"]
+          "enum": [
+            "AGGREGIERTER_EINTRAG",
+            "EINTRAG",
+            "SUMMEN_EINTRAG_ZUM_ZINSBINDUNGSENDE"
+          ]
         },
         "zahlung": {
           "type": "number"
         },
         "zahlungsTyp": {
           "type": "string",
-          "enum": ["AUSZAHLUNG", "EINZAHLUNG"]
+          "enum": [
+            "AUSZAHLUNG",
+            "EINZAHLUNG"
+          ]
         },
         "zinsen": {
           "type": "number"
@@ -2528,7 +2736,10 @@
         },
         "grundstuecksEigentuemer": {
           "type": "string",
-          "enum": ["ANDERE", "OEFFENTLICH_KIRCHLICH"]
+          "enum": [
+            "ANDERE",
+            "OEFFENTLICH_KIRCHLICH"
+          ]
         },
         "laufzeitBisJahr": {
           "type": "string",
@@ -2668,7 +2879,11 @@
         },
         "objektArt": {
           "type": "string",
-          "enum": ["EIGENTUMSWOHNUNG", "GRUNDSTUECK", "HAUS"]
+          "enum": [
+            "EIGENTUMSWOHNUNG",
+            "GRUNDSTUECK",
+            "HAUS"
+          ]
         },
         "vergleichsmieteFuerGewerbeflaecheProQm": {
           "type": "number",
@@ -2850,12 +3065,22 @@
         },
         "hausAnordnung": {
           "type": "string",
-          "enum": ["FREISTEHEND", "KOPFHAUS", "MITTELHAUS"]
+          "enum": [
+            "FREISTEHEND",
+            "KOPFHAUS",
+            "MITTELHAUS"
+          ]
         },
         "hausTyp": {
           "type": "string",
           "description": "Nur bei ObjektArt == HAUS.",
-          "enum": ["DOPPELHAUSHAELFTE", "EINFAMILIENHAUS", "MEHRFAMILIENHAUS", "REIHENHAUS", "ZWEIFAMILIENHAUS"]
+          "enum": [
+            "DOPPELHAUSHAELFTE",
+            "EINFAMILIENHAUS",
+            "MEHRFAMILIENHAUS",
+            "REIHENHAUS",
+            "ZWEIFAMILIENHAUS"
+          ]
         },
         "istFertighaus": {
           "type": "boolean",
@@ -2890,7 +3115,13 @@
         "zustand": {
           "type": "string",
           "description": "Angaben zum Zustand der Immobilie für die automatische Objektbewertungs-Schnittstelle (VDP)",
-          "enum": ["GUT", "MAESSIG", "MITTEL", "SCHLECHT", "SEHR_GUT"]
+          "enum": [
+            "GUT",
+            "MAESSIG",
+            "MITTEL",
+            "SCHLECHT",
+            "SEHR_GUT"
+          ]
         }
       },
       "title": "Gebaeude"
@@ -2909,7 +3140,9 @@
     },
     "Gegenangebot": {
       "type": "object",
-      "required": ["darlehen"],
+      "required": [
+        "darlehen"
+      ],
       "properties": {
         "darlehen": {
           "type": "array",
@@ -3270,7 +3503,11 @@
             "kfwEnergieEffizienzGruppe": {
               "type": "string",
               "description": "Nur benötigt, wenn kfwProgramm = PROGRAMM_261, PROGRAMM_262",
-              "enum": ["NEUBAU", "SANIERUNG", "STANDARD"]
+              "enum": [
+                "NEUBAU",
+                "SANIERUNG",
+                "STANDARD"
+              ]
             },
             "kfwEnergieEffizienzStandard": {
               "type": "string",
@@ -3417,12 +3654,19 @@
         },
         "vermoegensEinsatz": {
           "type": "string",
-          "enum": ["ABTRETEN", "AUFLOESEN", "KEIN_EINSATZ"]
+          "enum": [
+            "ABTRETEN",
+            "AUFLOESEN",
+            "KEIN_EINSATZ"
+          ]
         },
         "vermoegensTyp": {
           "type": "string",
           "description": "Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium",
-          "enum": ["VERBINDLICHKEIT", "VERMOEGEN"]
+          "enum": [
+            "VERBINDLICHKEIT",
+            "VERMOEGEN"
+          ]
         },
         "versicherungsGesellschaft": {
           "type": "string"
@@ -3447,7 +3691,10 @@
         "zahlungsTyp": {
           "type": "string",
           "description": "Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium",
-          "enum": ["AUSGABE", "EINNAHME"]
+          "enum": [
+            "AUSGABE",
+            "EINNAHME"
+          ]
         }
       },
       "title": "LebensOderRentenversicherungVermoegen"
@@ -3464,7 +3711,11 @@
         },
         "ausweisArt": {
           "type": "string",
-          "enum": ["ANDERE", "PERSONALAUSWEIS", "REISEPASS"]
+          "enum": [
+            "ANDERE",
+            "PERSONALAUSWEIS",
+            "REISEPASS"
+          ]
         },
         "ausweisArtBeiAndererAusweis": {
           "type": "string",
@@ -3528,7 +3779,10 @@
         "zahlungsTyp": {
           "type": "string",
           "description": "Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium",
-          "enum": ["AUSGABE", "EINNAHME"]
+          "enum": [
+            "AUSGABE",
+            "EINNAHME"
+          ]
         }
       },
       "title": "MietAusgaben"
@@ -3556,7 +3810,12 @@
         "modernisierungGrad": {
           "type": "string",
           "description": "Erlaubte Werte sind: UEBERWIEGEND,UMFASSEND,MITTEL,EINFACH. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können.",
-          "enum": ["EINFACH", "MITTEL", "UEBERWIEGEND", "UMFASSEND"]
+          "enum": [
+            "EINFACH",
+            "MITTEL",
+            "UEBERWIEGEND",
+            "UMFASSEND"
+          ]
         },
         "modernisierungsArt": {
           "type": "string",
@@ -3718,7 +3977,14 @@
         "op": {
           "type": "string",
           "description": "Auszuführende Operation",
-          "enum": ["add", "copy", "move", "remove", "replace", "test"]
+          "enum": [
+            "add",
+            "copy",
+            "move",
+            "remove",
+            "replace",
+            "test"
+          ]
         },
         "path": {
           "type": "string",
@@ -4009,7 +4275,11 @@
             },
             "regionalFoerderbankProgramm": {
               "type": "string",
-              "enum": ["L_BANK_KOMBI_DARLEHEN_WOHNEN", "L_BANK_WOHNEN_MIT_KIND", "NRW_BANK_WOHNEIGENTUM"]
+              "enum": [
+                "L_BANK_KOMBI_DARLEHEN_WOHNEN",
+                "L_BANK_WOHNEN_MIT_KIND",
+                "NRW_BANK_WOHNEIGENTUM"
+              ]
             },
             "sollZins": {
               "type": "number"
@@ -4053,7 +4323,13 @@
         },
         "auszahlungsTurnus": {
           "type": "string",
-          "enum": ["EINMALIG", "HALBJAEHRLICH", "JAEHRLICH", "MONATLICH", "VIERTELJAEHRLICH"]
+          "enum": [
+            "EINMALIG",
+            "HALBJAEHRLICH",
+            "JAEHRLICH",
+            "MONATLICH",
+            "VIERTELJAEHRLICH"
+          ]
         },
         "praemienAnteil": {
           "type": "number"
@@ -4113,7 +4389,13 @@
         },
         "zahlweise": {
           "type": "string",
-          "enum": ["EINMALIG", "HALBJAEHRLICH", "JAEHRLICH", "MONATLICH", "VIERTELJAEHRLICH"]
+          "enum": [
+            "EINMALIG",
+            "HALBJAEHRLICH",
+            "JAEHRLICH",
+            "MONATLICH",
+            "VIERTELJAEHRLICH"
+          ]
         }
       },
       "title": "SonderZahlung"
@@ -4149,12 +4431,18 @@
         "vermoegensTyp": {
           "type": "string",
           "description": "Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium",
-          "enum": ["VERBINDLICHKEIT", "VERMOEGEN"]
+          "enum": [
+            "VERBINDLICHKEIT",
+            "VERMOEGEN"
+          ]
         },
         "zahlungsTyp": {
           "type": "string",
           "description": "Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium",
-          "enum": ["AUSGABE", "EINNAHME"]
+          "enum": [
+            "AUSGABE",
+            "EINNAHME"
+          ]
         }
       },
       "title": "Sparplaene"
@@ -4173,7 +4461,10 @@
     },
     "StatusDTO": {
       "type": "object",
-      "required": ["antragsteller", "produktAnbieter"],
+      "required": [
+        "antragsteller",
+        "produktAnbieter"
+      ],
       "properties": {
         "ablehnungsgrund": {
           "type": "string",
@@ -4189,14 +4480,24 @@
         },
         "antragsteller": {
           "type": "string",
-          "enum": ["BEANTRAGT", "NICHT_ANGENOMMEN", "UNTERSCHRIEBEN", "WIDERRUFEN"]
+          "enum": [
+            "BEANTRAGT",
+            "NICHT_ANGENOMMEN",
+            "UNTERSCHRIEBEN",
+            "WIDERRUFEN"
+          ]
         },
         "kommentar": {
           "type": "string"
         },
         "produktAnbieter": {
           "type": "string",
-          "enum": ["ABGELEHNT", "NICHT_BEARBEITET", "UNTERSCHRIEBEN", "ZURUECKGESTELLT"]
+          "enum": [
+            "ABGELEHNT",
+            "NICHT_BEARBEITET",
+            "UNTERSCHRIEBEN",
+            "ZURUECKGESTELLT"
+          ]
         }
       },
       "title": "StatusDTO"
@@ -4359,7 +4660,10 @@
         "vermoegensTyp": {
           "type": "string",
           "description": "Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium",
-          "enum": ["VERBINDLICHKEIT", "VERMOEGEN"]
+          "enum": [
+            "VERBINDLICHKEIT",
+            "VERMOEGEN"
+          ]
         },
         "wirdAbgeloest": {
           "type": "boolean"
@@ -4367,7 +4671,10 @@
         "zahlungsTyp": {
           "type": "string",
           "description": "Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium",
-          "enum": ["AUSGABE", "EINNAHME"]
+          "enum": [
+            "AUSGABE",
+            "EINNAHME"
+          ]
         }
       },
       "title": "Verbindlichkeit"
@@ -4380,7 +4687,11 @@
         },
         "nutzungsArt": {
           "type": "string",
-          "enum": ["EIGENGENUTZT", "TEIL_VERMIETET", "VERMIETET"]
+          "enum": [
+            "EIGENGENUTZT",
+            "TEIL_VERMIETET",
+            "VERMIETET"
+          ]
         },
         "vermieteteFlaeche": {
           "type": "number"
@@ -4400,7 +4711,10 @@
         "vermoegensTyp": {
           "type": "string",
           "description": "Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium",
-          "enum": ["VERBINDLICHKEIT", "VERMOEGEN"]
+          "enum": [
+            "VERBINDLICHKEIT",
+            "VERMOEGEN"
+          ]
         }
       },
       "title": "Vermoegen"
@@ -4422,7 +4736,10 @@
         },
         "vermoegensTyp": {
           "type": "string",
-          "enum": ["VERBINDLICHKEIT", "VERMOEGEN"]
+          "enum": [
+            "VERBINDLICHKEIT",
+            "VERMOEGEN"
+          ]
         }
       },
       "title": "VermoegenVerbindlichkeit"
@@ -4522,12 +4839,18 @@
         "vermoegensTyp": {
           "type": "string",
           "description": "Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium",
-          "enum": ["VERBINDLICHKEIT", "VERMOEGEN"]
+          "enum": [
+            "VERBINDLICHKEIT",
+            "VERMOEGEN"
+          ]
         },
         "zahlungsTyp": {
           "type": "string",
           "description": "Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium",
-          "enum": ["AUSGABE", "EINNAHME"]
+          "enum": [
+            "AUSGABE",
+            "EINNAHME"
+          ]
         }
       },
       "title": "Wertpapiere"
@@ -4615,7 +4938,9 @@
         },
         "typ": {
           "type": "string",
-          "enum": ["TILGUNGSPLAN"]
+          "enum": [
+            "TILGUNGSPLAN"
+          ]
         }
       },
       "title": "zahlungsplan",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2,7 +2,7 @@
 swagger: "2.0"
 info:
   description: Mit dieser API können die Anträge durch die Produktanbieter abgerufen werden. Dabei wird ausschließlich der Kontext des Produktanbieters eingenommen.
-  version: "2.39"
+  version: "2.40"
   title: Anträge API
   contact:
     name: Europace AG
@@ -11,344 +11,344 @@ info:
 host: baufismart.api.europace.de
 basePath: /
 tags:
-  - name: Antraege
-    description: Zugriff auf Anträge für die Kreditentscheidung
+- name: Antraege
+  description: Zugriff auf Anträge für die Kreditentscheidung
 schemes:
-  - https
+- https
 paths:
   /v2/antraege:
     get:
       tags:
-        - Antraege
+      - Antraege
       summary: Alle Anträge abrufen
       description: "Es werden alle Anträge ausgeliefert, die der authentifizierten Partner sehen darf. Offen: Sortierung, Pagination, Filterung"
       operationId: getAlleAntraege
       produces:
-        - application/json;charset=UTF-8
+      - application/json;charset=UTF-8
       parameters:
-        - name: aenderungBis
-          in: query
-          description: Datum im ISO Format UTC - Zulu
-          required: false
-          type: string
-          x-example: 2016-03-11T10:57:45Z
-        - name: aenderungSeit
-          in: query
-          description: Datum im ISO Format UTC - Zulu
-          required: false
-          type: string
-          x-example: 2016-03-11T10:57:45Z
-        - name: angenommenNach
-          in: query
-          description: Datum im ISO Format UTC - Zulu
-          required: false
-          type: string
-          x-example: 2016-03-11T10:57:45Z
-        - name: angenommenVor
-          in: query
-          description: Datum im ISO Format UTC - Zulu. Setzen des Parameters erzwingt das Zulu Datumsformat für beide 'angenommen' Parameter.
-          required: false
-          type: string
-          x-example: 2016-03-11T10:57:45Z
-        - name: antragsReferenz
-          in: query
-          description: Suche nach deiner antragsReferenz
-          required: false
-          type: string
-        - name: datenKontext
-          in: query
-          description: Datenkontext
-          required: false
-          type: string
-          default: ECHT_GESCHAEFT
-          enum:
-            - ECHT_GESCHAEFT
-            - TEST_MODUS
-        - name: limit
-          in: query
-          description: limit
-          required: false
-          type: integer
-          default: 10
-          format: int32
-        - name: page
-          in: query
-          description: page
-          required: false
-          type: integer
-          default: 0
-          format: int32
-        - name: produktAnbieter
-          in: query
-          description: produktAnbieter
-          required: false
-          type: string
-        - name: sort
-          in: query
-          description: "Sortierung der Anträge, aufsteigend oder absteigend"
-          required: false
-          type: string
-          default: absteigend
-        - name: X-TraceId
-          in: header
-          required: false
-          type: string
+      - name: aenderungBis
+        in: query
+        description: Datum im ISO Format UTC - Zulu
+        required: false
+        type: string
+        x-example: 2016-03-11T10:57:45Z
+      - name: aenderungSeit
+        in: query
+        description: Datum im ISO Format UTC - Zulu
+        required: false
+        type: string
+        x-example: 2016-03-11T10:57:45Z
+      - name: angenommenNach
+        in: query
+        description: Datum im ISO Format UTC - Zulu
+        required: false
+        type: string
+        x-example: 2016-03-11T10:57:45Z
+      - name: angenommenVor
+        in: query
+        description: Datum im ISO Format UTC - Zulu. Setzen des Parameters erzwingt das Zulu Datumsformat für beide 'angenommen' Parameter.
+        required: false
+        type: string
+        x-example: 2016-03-11T10:57:45Z
+      - name: antragsReferenz
+        in: query
+        description: Suche nach deiner antragsReferenz
+        required: false
+        type: string
+      - name: datenKontext
+        in: query
+        description: Datenkontext
+        required: false
+        type: string
+        default: ECHT_GESCHAEFT
+        enum:
+        - ECHT_GESCHAEFT
+        - TEST_MODUS
+      - name: limit
+        in: query
+        description: limit
+        required: false
+        type: integer
+        default: 10
+        format: int32
+      - name: page
+        in: query
+        description: page
+        required: false
+        type: integer
+        default: 0
+        format: int32
+      - name: produktAnbieter
+        in: query
+        description: produktAnbieter
+        required: false
+        type: string
+      - name: sort
+        in: query
+        description: "Sortierung der Anträge, aufsteigend oder absteigend"
+        required: false
+        type: string
+        default: absteigend
+      - name: X-TraceId
+        in: header
+        required: false
+        type: string
       responses:
         "200":
           description: OK
           schema:
-            $ref: "#/definitions/Antraege"
+            $ref: '#/definitions/Antraege'
         "400":
           description: Client Error
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "403":
           description: Forbidden
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "404":
           description: Not Found
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "500":
           description: Internal Server Error
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
       security:
-        - OAuth2:
-            - baufinanzierung:antrag:lesen
+      - OAuth2:
+        - baufinanzierung:antrag:lesen
   /v2/antraege/{vorgang}:
     get:
       tags:
-        - Antraege
+      - Antraege
       summary: Alle Anträge eines Vorgangs abrufen
       description: Als Parameter wird die Vorgangsnummer in der Form 'AB1234' verwendet.
       operationId: getAntraegeByVorgangNummer
       produces:
-        - application/json;charset=UTF-8
+      - application/json;charset=UTF-8
       parameters:
-        - name: vorgang
-          in: path
-          description: Nummer des Antrags
-          required: true
-          type: string
-          x-example: AB1234
-        - name: X-TraceId
-          in: header
-          required: false
-          type: string
+      - name: vorgang
+        in: path
+        description: Nummer des Antrags
+        required: true
+        type: string
+        x-example: AB1234
+      - name: X-TraceId
+        in: header
+        required: false
+        type: string
       responses:
         "200":
           description: OK
           schema:
-            $ref: "#/definitions/Antraege"
+            $ref: '#/definitions/Antraege'
         "400":
           description: Client Error
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "403":
           description: Forbidden
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "404":
           description: Not Found
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "500":
           description: Internal Server Error
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
       security:
-        - OAuth2:
-            - baufinanzierung:antrag:lesen
+      - OAuth2:
+        - baufinanzierung:antrag:lesen
   /v2/antraege/{vorgang}/{antrag}:
     get:
       tags:
-        - Antraege
+      - Antraege
       summary: Teilanträge eines Antrags abrufen
       description: Als Parameter wird die Vorgangs- und Antragsnummer in der Form 'AB1234/1' verwendet.
       operationId: getAntrag
       produces:
-        - application/json;charset=UTF-8
+      - application/json;charset=UTF-8
       parameters:
-        - name: antrag
-          in: path
-          description: antrag
-          required: true
-          type: integer
-          format: int32
-        - name: vorgang
-          in: path
-          description: Nummer des Antrags
-          required: true
-          type: string
-          x-example: AB1234/1
-        - name: X-TraceId
-          in: header
-          required: false
-          type: string
+      - name: antrag
+        in: path
+        description: antrag
+        required: true
+        type: integer
+        format: int32
+      - name: vorgang
+        in: path
+        description: Nummer des Antrags
+        required: true
+        type: string
+        x-example: AB1234/1
+      - name: X-TraceId
+        in: header
+        required: false
+        type: string
       responses:
         "200":
           description: OK
           schema:
-            $ref: "#/definitions/Antraege"
+            $ref: '#/definitions/Antraege'
         "400":
           description: Client Error
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "403":
           description: Forbidden
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "404":
           description: Not Found
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "500":
           description: Internal Server Error
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
       security:
-        - OAuth2:
-            - baufinanzierung:antrag:lesen
+      - OAuth2:
+        - baufinanzierung:antrag:lesen
   /v2/antraege/{vorgang}/{antrag}/{teilantrag}:
     get:
       tags:
-        - Antraege
+      - Antraege
       summary: Einzelnen Antrag abrufen
       description: Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.
       operationId: getAntrag_1
       produces:
-        - application/json;charset=UTF-8
+      - application/json;charset=UTF-8
       parameters:
-        - name: antrag
-          in: path
-          description: antrag
-          required: true
-          type: integer
-          format: int32
-        - name: teilantrag
-          in: path
-          description: teilantrag
-          required: true
-          type: integer
-          format: int32
-        - name: vorgang
-          in: path
-          description: Nummer des Antrags
-          required: true
-          type: string
-          x-example: AB1234/1/2
-        - name: X-TraceId
-          in: header
-          required: false
-          type: string
+      - name: antrag
+        in: path
+        description: antrag
+        required: true
+        type: integer
+        format: int32
+      - name: teilantrag
+        in: path
+        description: teilantrag
+        required: true
+        type: integer
+        format: int32
+      - name: vorgang
+        in: path
+        description: Nummer des Antrags
+        required: true
+        type: string
+        x-example: AB1234/1/2
+      - name: X-TraceId
+        in: header
+        required: false
+        type: string
       responses:
         "200":
           description: OK
           schema:
-            $ref: "#/definitions/Antrag"
+            $ref: '#/definitions/Antrag'
         "400":
           description: Client Error
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "403":
           description: Forbidden
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "404":
           description: Not Found
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "500":
           description: Internal Server Error
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
       security:
-        - OAuth2:
-            - baufinanzierung:antrag:lesen
+      - OAuth2:
+        - baufinanzierung:antrag:lesen
     patch:
       tags:
-        - Antraege
+      - Antraege
       summary: Antrag aktualisieren
       description: Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet. Es können mehrere Operationen gleichzeitig übertragen werden.
       operationId: updateAntrag
       consumes:
-        - application/json-patch+json
-        - application/json
+      - application/json-patch+json
+      - application/json
       produces:
-        - "*/*"
+      - '*/*'
       parameters:
-        - name: antrag
-          in: path
-          description: antrag
-          required: true
-          type: integer
-          format: int32
-        - name: Authorization
-          in: header
-          required: false
-          type: string
-        - in: body
-          name: patchOperations
-          description: patchOperations
-          required: true
-          schema:
-            type: array
-            items:
-              $ref: "#/definitions/PatchOperation"
-        - name: teilantrag
-          in: path
-          description: teilantrag
-          required: true
-          type: integer
-          format: int32
-        - name: vorgang
-          in: path
-          description: Nummer des Antrags
-          required: true
-          type: string
-          x-example: AB1234/1/2
-        - name: X-Authentication
-          in: header
-          required: false
-          type: string
-        - name: X-TraceId
-          in: header
-          required: false
-          type: string
+      - name: antrag
+        in: path
+        description: antrag
+        required: true
+        type: integer
+        format: int32
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+      - in: body
+        name: patchOperations
+        description: patchOperations
+        required: true
+        schema:
+          type: array
+          items:
+            $ref: '#/definitions/PatchOperation'
+      - name: teilantrag
+        in: path
+        description: teilantrag
+        required: true
+        type: integer
+        format: int32
+      - name: vorgang
+        in: path
+        description: Nummer des Antrags
+        required: true
+        type: string
+        x-example: AB1234/1/2
+      - name: X-Authentication
+        in: header
+        required: false
+        type: string
+      - name: X-TraceId
+        in: header
+        required: false
+        type: string
       responses:
         "204":
           description: No Content
@@ -357,250 +357,250 @@ paths:
         "403":
           description: Forbidden
       security:
-        - OAuth2:
-            - baufinanzierung:antrag:schreiben
+      - OAuth2:
+        - baufinanzierung:antrag:schreiben
   /v2/antraege/{vorgang}/{antrag}/{teilantrag}/angebot:
     get:
       tags:
-        - Antraege
+      - Antraege
       summary: Angebot des Antrags abrufen
       description: "Es handelt sich um das angenommene Angebot, das zu diesem Antrag geführt hat."
       operationId: getAngebot
       produces:
-        - application/json;charset=UTF-8
+      - application/json;charset=UTF-8
       parameters:
-        - name: antrag
-          in: path
-          description: antrag
-          required: true
-          type: integer
-          format: int32
-        - name: teilantrag
-          in: path
-          description: teilantrag
-          required: true
-          type: integer
-          format: int32
-        - name: vorgang
-          in: path
-          description: "Nummer des Antrags, bestehend aus Vorgangsnummer und Antragnummer."
-          required: true
-          type: string
-          x-example: AB1234/1
-        - name: X-TraceId
-          in: header
-          required: false
-          type: string
+      - name: antrag
+        in: path
+        description: antrag
+        required: true
+        type: integer
+        format: int32
+      - name: teilantrag
+        in: path
+        description: teilantrag
+        required: true
+        type: integer
+        format: int32
+      - name: vorgang
+        in: path
+        description: "Nummer des Antrags, bestehend aus Vorgangsnummer und Antragnummer."
+        required: true
+        type: string
+        x-example: AB1234/1
+      - name: X-TraceId
+        in: header
+        required: false
+        type: string
       responses:
         "200":
           description: OK
           schema:
-            $ref: "#/definitions/AngebotZumAntrag"
+            $ref: '#/definitions/AngebotZumAntrag'
         "400":
           description: Client Error
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "403":
           description: Forbidden
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "404":
           description: Not Found
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "500":
           description: Internal Server Error
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
       security:
-        - OAuth2:
-            - baufinanzierung:antrag:lesen
+      - OAuth2:
+        - baufinanzierung:antrag:lesen
   /v2/antraege/{vorgang}/{antrag}/{teilantrag}/angebot/zahlungsplaene:
     get:
       tags:
-        - Antraege
+      - Antraege
       summary: Die Zahlungsplaene (Tilgungs- & Sparpläne) des angenommenen Angebots.
       description: Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.
       operationId: getZahlungsplaene
       produces:
-        - application/json;charset=UTF-8
+      - application/json;charset=UTF-8
       parameters:
-        - name: antrag
-          in: path
-          description: Nummer des Antrags
-          required: true
-          type: integer
-          format: int32
-          x-example: 1
-        - name: teilantrag
-          in: path
-          description: Nummer des Teilantrags
-          required: true
-          type: integer
-          format: int32
-          x-example: 1
-        - name: vorgang
-          in: path
-          description: Nummer des Vorgangs
-          required: true
-          type: string
-          x-example: AB1234
-        - name: X-TraceId
-          in: header
-          required: false
-          type: string
+      - name: antrag
+        in: path
+        description: Nummer des Antrags
+        required: true
+        type: integer
+        format: int32
+        x-example: 1
+      - name: teilantrag
+        in: path
+        description: Nummer des Teilantrags
+        required: true
+        type: integer
+        format: int32
+        x-example: 1
+      - name: vorgang
+        in: path
+        description: Nummer des Vorgangs
+        required: true
+        type: string
+        x-example: AB1234
+      - name: X-TraceId
+        in: header
+        required: false
+        type: string
       responses:
         "200":
           description: OK
           schema:
-            $ref: "#/definitions/Zahlungsplaene"
+            $ref: '#/definitions/Zahlungsplaene'
         "400":
           description: Client Error
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "403":
           description: Forbidden
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "404":
           description: Not Found
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "500":
           description: Internal Server Error
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
       security:
-        - OAuth2:
-            - baufinanzierung:antrag:lesen
+      - OAuth2:
+        - baufinanzierung:antrag:lesen
   /v2/antraege/{vorgang}/{antrag}/{teilantrag}/ansprechpartner:
     get:
       tags:
-        - Antraege
+      - Antraege
       summary: Den Ansprechpartner (Vertrieb) des  Teilantrags abrufen.
       description: Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet.
       operationId: getAnsprechpartner
       produces:
-        - application/json;charset=UTF-8
+      - application/json;charset=UTF-8
       parameters:
-        - name: antrag
-          in: path
-          description: antrag
-          required: true
-          type: integer
-          format: int32
-        - name: teilantrag
-          in: path
-          description: teilantrag
-          required: true
-          type: integer
-          format: int32
-        - name: vorgang
-          in: path
-          description: Nummer des Antrags
-          required: true
-          type: string
-          x-example: AB1234/1/2
-        - name: X-TraceId
-          in: header
-          required: false
-          type: string
+      - name: antrag
+        in: path
+        description: antrag
+        required: true
+        type: integer
+        format: int32
+      - name: teilantrag
+        in: path
+        description: teilantrag
+        required: true
+        type: integer
+        format: int32
+      - name: vorgang
+        in: path
+        description: Nummer des Antrags
+        required: true
+        type: string
+        x-example: AB1234/1/2
+      - name: X-TraceId
+        in: header
+        required: false
+        type: string
       responses:
         "200":
           description: OK
           schema:
-            $ref: "#/definitions/Partner"
+            $ref: '#/definitions/Partner'
         "400":
           description: Client Error
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "403":
           description: Forbidden
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "404":
           description: Not Found
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
         "500":
           description: Internal Server Error
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
       security:
-        - OAuth2:
-            - baufinanzierung:antrag:lesen
+      - OAuth2:
+        - baufinanzierung:antrag:lesen
   /v2/antraege/{vorgang}/{antrag}/{teilantrag}/gegenangebot:
     post:
       tags:
-        - Antraege
+      - Antraege
       summary: Ein Gegenangebot erstellen
       description: Als Parameter wird die komplette Antragsnummer in der Form 'AB1234/1/2' verwendet. Das übergebene Angebot wird sofort als Gegenangebot gestellt. Der alte Antrag wird abgelehnt.
       operationId: erstelleGegenangebot
       consumes:
-        - application/json
+      - application/json
       produces:
-        - application/json
+      - application/json
       parameters:
-        - name: antrag
-          in: path
-          description: antrag
-          required: true
-          type: integer
-          format: int32
-        - name: Authorization
-          in: header
-          required: false
-          type: string
-        - in: body
-          name: gegenangebot
-          description: gegenangebot
-          required: true
-          schema:
-            $ref: "#/definitions/Gegenangebot"
-        - name: teilantrag
-          in: path
-          description: teilantrag
-          required: true
-          type: integer
-          format: int32
-        - name: vorgang
-          in: path
-          description: Nummer des Antrags
-          required: true
-          type: string
-          x-example: AB1234/1/2
-        - name: X-Authentication
-          in: header
-          required: false
-          type: string
-        - name: X-TraceId
-          in: header
-          required: false
-          type: string
+      - name: antrag
+        in: path
+        description: antrag
+        required: true
+        type: integer
+        format: int32
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+      - in: body
+        name: gegenangebot
+        description: gegenangebot
+        required: true
+        schema:
+          $ref: '#/definitions/Gegenangebot'
+      - name: teilantrag
+        in: path
+        description: teilantrag
+        required: true
+        type: integer
+        format: int32
+      - name: vorgang
+        in: path
+        description: Nummer des Antrags
+        required: true
+        type: string
+        x-example: AB1234/1/2
+      - name: X-Authentication
+        in: header
+        required: false
+        type: string
+      - name: X-TraceId
+        in: header
+        required: false
+        type: string
       responses:
         "201":
           description: Created
@@ -609,7 +609,7 @@ paths:
         "400":
           description: Client Error
           schema:
-            $ref: "#/definitions/Problem"
+            $ref: '#/definitions/Problem'
         "401":
           description: Unauthorized
         "403":
@@ -617,55 +617,55 @@ paths:
         "404":
           description: Not Found
       security:
-        - OAuth2:
-            - baufinanzierung:antrag:schreiben
-            - baufinanzierung:echtgeschaeft
+      - OAuth2:
+        - baufinanzierung:antrag:schreiben
+        - baufinanzierung:echtgeschaeft
   /v2/antraege/{vorgang}/{antrag}/{teilantrag}/status:
     post:
       tags:
-        - Antraege
+      - Antraege
       summary: Setzen des Antragsstatus
       operationId: setAntragsStatus_1
       consumes:
-        - application/json
+      - application/json
       produces:
-        - application/json;charset=UTF-8
+      - application/json;charset=UTF-8
       parameters:
-        - name: antrag
-          in: path
-          description: antrag
-          required: true
-          type: integer
-          format: int32
-        - name: Authorization
-          in: header
-          required: false
-          type: string
-        - in: body
-          name: statusDTO
-          description: statusDTO
-          required: true
-          schema:
-            $ref: "#/definitions/StatusDTO"
-        - name: teilantrag
-          in: path
-          description: teilantrag
-          required: true
-          type: integer
-          format: int32
-        - name: vorgang
-          in: path
-          description: vorgang
-          required: true
-          type: string
-        - name: X-Authentication
-          in: header
-          required: false
-          type: string
-        - name: X-TraceId
-          in: header
-          required: false
-          type: string
+      - name: antrag
+        in: path
+        description: antrag
+        required: true
+        type: integer
+        format: int32
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+      - in: body
+        name: statusDTO
+        description: statusDTO
+        required: true
+        schema:
+          $ref: '#/definitions/StatusDTO'
+      - name: teilantrag
+        in: path
+        description: teilantrag
+        required: true
+        type: integer
+        format: int32
+      - name: vorgang
+        in: path
+        description: vorgang
+        required: true
+        type: string
+      - name: X-Authentication
+        in: header
+        required: false
+        type: string
+      - name: X-TraceId
+        in: header
+        required: false
+        type: string
       responses:
         "201":
           description: Created
@@ -678,8 +678,8 @@ paths:
         "404":
           description: Not Found
       security:
-        - OAuth2:
-            - baufinanzierung:antrag:schreiben
+      - OAuth2:
+        - baufinanzierung:antrag:schreiben
 securityDefinitions:
   Bearer:
     type: apiKey
@@ -700,7 +700,7 @@ definitions:
       abgesicherteRisiken:
         type: array
         items:
-          $ref: "#/definitions/RisikoAbsicherung"
+          $ref: '#/definitions/RisikoAbsicherung'
       externeAngebotsNummer:
         type: string
       gesamtPraemie:
@@ -708,11 +708,11 @@ definitions:
       praemienZahlungsweise:
         type: string
         enum:
-          - EINMALIG
-          - HALBJAEHRLICH
-          - JAEHRLICH
-          - MONATLICH
-          - VIERTELJAEHRLICH
+        - EINMALIG
+        - HALBJAEHRLICH
+        - JAEHRLICH
+        - MONATLICH
+        - VIERTELJAEHRLICH
       tarifBezeichnung:
         type: string
       tarifKennung:
@@ -724,7 +724,7 @@ definitions:
       versicherungsNummer:
         type: string
       versicherungsZeitraum:
-        $ref: "#/definitions/VersicherungsZeitraum"
+        $ref: '#/definitions/VersicherungsZeitraum'
     title: Absicherung
   AbsicherungsAngaben:
     type: object
@@ -736,30 +736,30 @@ definitions:
     type: object
     properties:
       _links:
-        $ref: "#/definitions/Links"
+        $ref: '#/definitions/Links'
       absicherungen:
         type: array
         items:
-          $ref: "#/definitions/Absicherung"
+          $ref: '#/definitions/Absicherung'
       bausparvertraege:
         type: array
         items:
-          $ref: "#/definitions/Bausparvertrag"
+          $ref: '#/definitions/Bausparvertrag'
       beleihungsRechnung:
-        $ref: "#/definitions/BeleihungsRechnung"
+        $ref: '#/definitions/BeleihungsRechnung'
       bewertungDesAngebots:
         type: string
         enum:
-          - ANGEBOT_ENTSPRICHT_DEM_WUNSCH_DES_KUNDEN
-          - ANGEBOT_ENTSPRICHT_DER_EMPFEHLUNG_DES_KUNDENBETREUERS
+        - ANGEBOT_ENTSPRICHT_DEM_WUNSCH_DES_KUNDEN
+        - ANGEBOT_ENTSPRICHT_DER_EMPFEHLUNG_DES_KUNDENBETREUERS
       bonitaet:
         type: array
         items:
-          $ref: "#/definitions/Bonitaet"
+          $ref: '#/definitions/Bonitaet'
       darlehen:
         type: array
         items:
-          $ref: "#/definitions/Darlehen"
+          $ref: '#/definitions/Darlehen'
       erzeugtAm:
         type: string
         format: date-time
@@ -769,93 +769,93 @@ definitions:
       machbarkeitsStatus:
         type: string
         enum:
-          - MACHBAR
-          - NICHT_MACHBAR
-          - UNTER_VORBEHALT_PRODUZENT
+        - MACHBAR
+        - NICHT_MACHBAR
+        - UNTER_VORBEHALT_PRODUZENT
       meldungen:
         type: array
         items:
-          $ref: "#/definitions/Meldung"
+          $ref: '#/definitions/Meldung'
       pruefungsErgebnisse:
         type: array
         description: Bewertungen seitens der Produktanbieter während der Angebotserstellung.
         items:
-          $ref: "#/definitions/AngebotsPruefungsErgebnis"
+          $ref: '#/definitions/AngebotsPruefungsErgebnis'
     title: AngebotZumAntrag
   AngebotsPruefungsErgebnis:
     type: object
     properties:
       bewertung:
-        $ref: "#/definitions/BewertungDurchProduktAnbieter"
+        $ref: '#/definitions/BewertungDurchProduktAnbieter'
       kfwKonditionsReservierung:
-        $ref: "#/definitions/KfwKonditionsReservierung"
+        $ref: '#/definitions/KfwKonditionsReservierung'
       produktAnbieterId:
         type: string
     title: AngebotsPruefungsErgebnis
   AnnuitaetenDarlehen:
     title: AnnuitaetenDarlehen
     allOf:
-      - $ref: "#/definitions/GegenangebotDarlehen"
-      - type: object
-        required:
-          - anfaenglicheTilgung
-          - bereitstellungsZinsFreieZeitInMonaten
-          - darlehensBetrag
-          - darlehensTyp
-          - effektivZins
-          - laufzeitKalkulatorischInJahren
-          - rateMonatlich
-          - sollZins
-          - sonderTilgungJaehrlich
-          - vertriebsProvisionGesamtAbsolut
-          - zinsBindungInJahren
-        discriminator: darlehensTyp
-        properties:
-          anfaenglicheTilgung:
-            type: number
-          bereitstellungsZins:
-            type: number
-          bereitstellungsZinsFreieZeitInMonaten:
-            type: integer
-            format: int32
-          darlehensBetrag:
-            type: number
-          darlehensTyp:
-            type: string
-            enum:
-              - ANNUITAETEN_DARLEHEN
-              - FORWARD_DARLEHEN
-              - KFW_DARLEHEN
-              - PRIVAT_DARLEHEN
-              - REGIONAL_FOERDER_DARLEHEN
-              - VARIABLES_DARLEHEN
-              - ZWISCHEN_FINANZIERUNG
-          effektivZins:
-            type: number
-          laufzeitKalkulatorischInJahren:
-            type: integer
-            format: int32
-          produktDetails:
-            type: string
-            description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
-          rateMonatlich:
-            type: number
-          sollZins:
-            type: number
-          sonderTilgungJaehrlich:
-            type: number
-          tilgungsBeginnAm:
-            type: string
-            format: date-time
-            example: 2020-03-28
-          vertriebsProvisionGesamtAbsolut:
-            type: number
-            description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
-          zinsBindungInJahren:
-            type: integer
-            format: int32
-        title: AnnuitaetenDarlehen
-        description: Erweitert GegenangebotDarlehen
+    - $ref: '#/definitions/GegenangebotDarlehen'
+    - type: object
+      required:
+      - anfaenglicheTilgung
+      - bereitstellungsZinsFreieZeitInMonaten
+      - darlehensBetrag
+      - darlehensTyp
+      - effektivZins
+      - laufzeitKalkulatorischInJahren
+      - rateMonatlich
+      - sollZins
+      - sonderTilgungJaehrlich
+      - vertriebsProvisionGesamtAbsolut
+      - zinsBindungInJahren
+      discriminator: darlehensTyp
+      properties:
+        anfaenglicheTilgung:
+          type: number
+        bereitstellungsZins:
+          type: number
+        bereitstellungsZinsFreieZeitInMonaten:
+          type: integer
+          format: int32
+        darlehensBetrag:
+          type: number
+        darlehensTyp:
+          type: string
+          enum:
+          - ANNUITAETEN_DARLEHEN
+          - FORWARD_DARLEHEN
+          - KFW_DARLEHEN
+          - PRIVAT_DARLEHEN
+          - REGIONAL_FOERDER_DARLEHEN
+          - VARIABLES_DARLEHEN
+          - ZWISCHEN_FINANZIERUNG
+        effektivZins:
+          type: number
+        laufzeitKalkulatorischInJahren:
+          type: integer
+          format: int32
+        produktDetails:
+          type: string
+          description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
+        rateMonatlich:
+          type: number
+        sollZins:
+          type: number
+        sonderTilgungJaehrlich:
+          type: number
+        tilgungsBeginnAm:
+          type: string
+          format: date-time
+          example: 2020-03-28
+        vertriebsProvisionGesamtAbsolut:
+          type: number
+          description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
+        zinsBindungInJahren:
+          type: integer
+          format: int32
+      title: AnnuitaetenDarlehen
+      description: Erweitert GegenangebotDarlehen
     description: Erweitert GegenangebotDarlehen
   Anschrift:
     type: object
@@ -873,23 +873,26 @@ definitions:
     type: object
     properties:
       _links:
-        $ref: "#/definitions/PaginationLinks"
+        $ref: '#/definitions/PaginationLinks'
       antraege:
         type: array
         items:
-          $ref: "#/definitions/Antrag"
+          $ref: '#/definitions/Antrag'
     title: Antraege
   Antrag:
     type: object
     properties:
       _links:
-        $ref: "#/definitions/Links"
+        $ref: '#/definitions/Links'
+      aktiverAntrag:
+        type: boolean
+        description: "Ein Produktanbieter kann nur einen aktiven Antrag an einem Vorgang haben. Dieses Feld zeigt an, welcher Antrag aktiv ist.Durch Statuswechsel wird diese Information verändert"
       angebot:
         description: "Das angenommene Angebot, auf dem dieser Antrag basiert"
-        $ref: "#/definitions/AngebotZumAntrag"
+        $ref: '#/definitions/AngebotZumAntrag'
       ansprechpartner:
         description: "Für Rückfragen auf Seite des Vertriebs, kann mit dem Vermittler identisch sein"
-        $ref: "#/definitions/Partner"
+        $ref: '#/definitions/Partner'
       antragsNummer:
         type: string
         description: Nummer des Antrags auf der Europace Plattform
@@ -898,39 +901,39 @@ definitions:
         description: Nummer des Antrags in deinem System (ändernbar)
       beratung:
         description: Informationen zum Geschäftsabschluss
-        $ref: "#/definitions/Beratung"
+        $ref: '#/definitions/Beratung'
       datenKontext:
         type: string
         description: "Gibt an, ob es sich um einen Antrag aus dem Testmodus oder Echtgeschäft handelt"
         enum:
-          - ECHT_GESCHAEFT
-          - TEST_MODUS
+        - ECHT_GESCHAEFT
+        - TEST_MODUS
       dokumente:
         type: array
         description: "Enthält alle Plattformdokumente, freigegebene Dokumente des Vertriebs, sowie die hochgeladenen Dokumente des Produktanbieters."
         uniqueItems: true
         items:
-          $ref: "#/definitions/Dokument"
+          $ref: '#/definitions/Dokument'
       entscheidungsreifeVomVertriebSignalisiert:
         type: boolean
         description: "Hinweis des Vertriebs, dass der Antrag fertig zur Bearbeitung ist."
       kreditSachbearbeiter:
         description: Gewählter Sachbearbeiter aus Seite des Kreditvertriebs
-        $ref: "#/definitions/Partner"
+        $ref: '#/definitions/Partner'
       letzteAenderung:
         type: string
         format: date-time
         description: Zeitpunkt der letzten Änderung des Antrags
       produktAnbieter:
-        $ref: "#/definitions/ProduktAnbieter"
+        $ref: '#/definitions/ProduktAnbieter'
       prolongation:
         type: boolean
       status:
         description: Bearbeitungsfortschritt des Antrags
-        $ref: "#/definitions/AntragsStatus"
+        $ref: '#/definitions/AntragsStatus'
       vermittler:
         description: Partner auf Seite des Vertriebs
-        $ref: "#/definitions/Partner"
+        $ref: '#/definitions/Partner'
       voraussichtlicheBearbeitung:
         type: string
         format: date
@@ -944,7 +947,7 @@ definitions:
         description: "Zeitpunkt, zu dem der Antrag im System erstellt wurde."
       zugrundeliegendeDaten:
         description: "Basisdaten des Kunden, die für die Berechnung des Angebots relevant waren"
-        $ref: "#/definitions/ZugrundeliegendeDatenZumAntrag"
+        $ref: '#/definitions/ZugrundeliegendeDatenZumAntrag'
     title: Antrag
     description: Diese Resource repräsentiert einen Antrag in Baufi Smart.
   AntragsStatus:
@@ -954,51 +957,51 @@ definitions:
         type: string
         description: Ablehnungsgrund des Produktanbieters
         enum:
-          - FINANZIELLE_SITUATION
-          - GEGENANGEBOT
-          - KEINE_ANGABE
-          - KRITERIEN
-          - NEGATIV_MERKMAL
-          - UNTERLAGEN_UNVOLLSTAENDIG
-          - WERTERMITTLUNG
+        - FINANZIELLE_SITUATION
+        - GEGENANGEBOT
+        - KEINE_ANGABE
+        - KRITERIEN
+        - NEGATIV_MERKMAL
+        - UNTERLAGEN_UNVOLLSTAENDIG
+        - WERTERMITTLUNG
       antragsteller:
         type: string
         description: Willenserklärung des Antragstellers
         enum:
-          - BEANTRAGT
-          - NICHT_ANGENOMMEN
-          - UNTERSCHRIEBEN
-          - WIDERRUFEN
+        - BEANTRAGT
+        - NICHT_ANGENOMMEN
+        - UNTERSCHRIEBEN
+        - WIDERRUFEN
       bearbeitungsFortschritt:
         type: string
         description: Bearbeitungsfortschritt des Antrags nach beidseitiger Unterzeichnung
         enum:
-          - FREIGEGEBEN_FUER_SAMMELFORDERUNG
-          - NICHT_VON_PRODUKTANBIETER_BESTAETIGT
-          - PROVISION_IN_BEARBEITUNG
-          - PROVISON_AN_KUNDENBETREUER_VOLLSTAENDIG_AUSGEZAHLT
-          - VON_PRODUKTANBIETER_BESTAETIGT
+        - FREIGEGEBEN_FUER_SAMMELFORDERUNG
+        - NICHT_VON_PRODUKTANBIETER_BESTAETIGT
+        - PROVISION_IN_BEARBEITUNG
+        - PROVISON_AN_KUNDENBETREUER_VOLLSTAENDIG_AUSGEZAHLT
+        - VON_PRODUKTANBIETER_BESTAETIGT
       produktAnbieter:
         type: string
         description: Willenserklärung des Produktanbieters
         enum:
-          - ABGELEHNT
-          - NICHT_BEARBEITET
-          - UNTERSCHRIEBEN
-          - ZURUECKGESTELLT
+        - ABGELEHNT
+        - NICHT_BEARBEITET
+        - UNTERSCHRIEBEN
+        - ZURUECKGESTELLT
     title: AntragsStatus
   Antragsteller:
     type: object
     properties:
       absicherungsAngaben:
-        $ref: "#/definitions/AbsicherungsAngaben"
+        $ref: '#/definitions/AbsicherungsAngaben'
       anrede:
         type: string
         enum:
-          - FRAU
-          - HERR
+        - FRAU
+        - HERR
       anschrift:
-        $ref: "#/definitions/Postadresse"
+        $ref: '#/definitions/Postadresse'
       arbeitserlaubnis:
         type: boolean
         description: wenn der Antragssteller die Staatsangehörigkeit eines Nicht-EU-Landes hat
@@ -1010,10 +1013,10 @@ definitions:
         type: string
         description: wenn der Antragssteller die Staatsangehörigkeit eines Nicht-EU-Landes hat
         enum:
-          - AUFENTHALTS_ERLAUBNIS
-          - DAUERAUFENTHALT_EU
-          - NIEDERLASSUNGS_ERLAUBNIS
-          - VISUM
+        - AUFENTHALTS_ERLAUBNIS
+        - DAUERAUFENTHALT_EU
+        - NIEDERLASSUNGS_ERLAUBNIS
+        - VISUM
       aufenthaltsTitelBefristetBis:
         type: string
         format: date
@@ -1022,14 +1025,14 @@ definitions:
         type: string
         description: "Berufsgruppe des Antragstellers (ING) Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt.. Erlaubte Werte sind:  ANGESTELLTER, ARBEITER, BEAMTER, FREIBERUFLER, SELBSTSTAENDIG, RENTNER, HAUSMANN, PRIVATIER, SOLDAT, SCHUELER, AZUBI, STUDENT, OHNE. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können."
       beschaeftigung:
-        $ref: "#/definitions/Beschaeftigung"
+        $ref: '#/definitions/Beschaeftigung'
       beschaeftigungImOeffentlichenDienstBeiDsl:
         type: boolean
       branche:
         type: array
         description: "Branchen je Produktanbieter, in welcher der Antragsteller tätig ist. Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können."
         items:
-          $ref: "#/definitions/Branche"
+          $ref: '#/definitions/Branche'
       brancheBeiIngDiba:
         type: string
         description: "Deprecated. Bitte das Feld 'branche' nutzen. Branche, in welcher der Antragsteller tätig ist. (ING) Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt.. Erlaubte Werte sind: BANKEN_VERSICHERUNGEN, BAUGEWERBE, DIENSTLEISTUNGEN_SONSTIGE, EDV_BERATUNG, ENERGIE, ERZIEHUNG_UNTERRICHT, GESUNDHEITSWESEN, HANDEL, HANDWERK, HOTEL_GASTRONOMIE, LANDWIRTSCHAFT, OEFFENTLICHER_DIENST, PRODUKTION_INDUSTRIE, VERKEHR. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können."
@@ -1050,12 +1053,12 @@ definitions:
       familienstand:
         type: string
         enum:
-          - GESCHIEDEN
-          - GETRENNT_LEBEND
-          - LEBENSPARTNERSCHAFT
-          - LEDIG
-          - VERHEIRATET
-          - VERWITWET
+        - GESCHIEDEN
+        - GETRENNT_LEBEND
+        - LEBENSPARTNERSCHAFT
+        - LEDIG
+        - VERHEIRATET
+        - VERWITWET
       geburtsdatum:
         type: string
         format: date
@@ -1073,15 +1076,15 @@ definitions:
         description: wenn der Antragssteller die Staatsangehörigkeit eines Nicht-EU-Landes hat
       legitimationsDaten:
         description: "Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt."
-        $ref: "#/definitions/LegitimationsDaten"
+        $ref: '#/definitions/LegitimationsDaten'
       nachname:
         type: string
       schufaErgebnis:
-        $ref: "#/definitions/SchufaErgebnis"
+        $ref: '#/definitions/SchufaErgebnis'
       sozialversicherungsnummer:
         type: string
       staatsangehoerigkeit:
-        $ref: "#/definitions/Staat"
+        $ref: '#/definitions/Staat'
       steuerId:
         type: string
       telefonnummer:
@@ -1094,9 +1097,9 @@ definitions:
         type: boolean
       verheiratetMitAntragsteller:
         description: nur wenn verheiratet
-        $ref: "#/definitions/AntragstellerVerknuepfung"
+        $ref: '#/definitions/AntragstellerVerknuepfung'
       vorAnschrift:
-        $ref: "#/definitions/Postadresse"
+        $ref: '#/definitions/Postadresse'
       vorname:
         type: string
       weitereKontaktMoeglichkeiten:
@@ -1123,8 +1126,8 @@ definitions:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-          - AUSGABE
-          - EINNAHME
+        - AUSGABE
+        - EINNAHME
     title: AusgabenMonatlich
   Autostellplatz:
     type: object
@@ -1134,12 +1137,12 @@ definitions:
       typ:
         type: string
         enum:
-          - CARPORT
-          - DOPPEL_GARAGE
-          - GARAGE
-          - KELLER_GARAGE
-          - STELLPLATZ
-          - TIEFGARAGEN_STELLPLATZ
+        - CARPORT
+        - DOPPEL_GARAGE
+        - GARAGE
+        - KELLER_GARAGE
+        - STELLPLATZ
+        - TIEFGARAGEN_STELLPLATZ
     title: Autostellplatz
   BankUndSparguthaben:
     type: object
@@ -1152,14 +1155,14 @@ definitions:
         type: string
         description: Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium
         enum:
-          - VERBINDLICHKEIT
-          - VERMOEGEN
+        - VERBINDLICHKEIT
+        - VERMOEGEN
       zahlungsTyp:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-          - AUSGABE
-          - EINNAHME
+        - AUSGABE
+        - EINNAHME
       zinsertragJaehrlich:
         type: number
     title: BankUndSparguthaben
@@ -1190,8 +1193,8 @@ definitions:
         type: string
         description: "Erlaubte Werte sind: SOFORTZAHLUNG, VERRECHNUNG"
         enum:
-          - SOFORTZAHLUNG
-          - VERRECHNUNG
+        - SOFORTZAHLUNG
+        - VERRECHNUNG
       angebotsHinweisFuerAntragsteller:
         type: string
         description: nur bei neuen extern berechneten Bausparverträgen und bei Gegenangeboten
@@ -1207,21 +1210,21 @@ definitions:
       id:
         type: string
       produktAnbieter:
-        $ref: "#/definitions/ProduktAnbieter"
+        $ref: '#/definitions/ProduktAnbieter'
       sonderZahlungen:
         type: array
         items:
-          $ref: "#/definitions/SonderZahlung"
+          $ref: '#/definitions/SonderZahlung'
       sparBeginn:
         type: string
         format: date
       sparPhase:
-        $ref: "#/definitions/SparPhase"
+        $ref: '#/definitions/SparPhase'
       tarif:
         type: string
         description: Tarifname
       tilgungsPhase:
-        $ref: "#/definitions/TilgungsPhase"
+        $ref: '#/definitions/TilgungsPhase'
       typ:
         type: string
       vertragsBeginn:
@@ -1233,7 +1236,7 @@ definitions:
         type: array
         description: nur bei neuen extern berechneten Bausparverträgen
         items:
-          $ref: "#/definitions/AntragstellerVerknuepfung"
+          $ref: '#/definitions/AntragstellerVerknuepfung'
       verwaltungsgebuehrenJaehrlich:
         type: number
       zuteilungsDatum:
@@ -1249,8 +1252,8 @@ definitions:
         type: string
         description: "Erlaubte Werte sind: SOFORTZAHLUNG, VERRECHNUNG"
         enum:
-          - SOFORTZAHLUNG
-          - VERRECHNUNG
+        - SOFORTZAHLUNG
+        - VERRECHNUNG
       angebotsHinweisFuerAntragsteller:
         type: string
         description: nur bei neuen extern berechneten Bausparverträgen und bei Gegenangeboten
@@ -1266,16 +1269,16 @@ definitions:
       id:
         type: string
       produktAnbieter:
-        $ref: "#/definitions/ProduktAnbieter"
+        $ref: '#/definitions/ProduktAnbieter'
       sonderZahlungen:
         type: array
         items:
-          $ref: "#/definitions/SonderZahlung"
+          $ref: '#/definitions/SonderZahlung'
       sparBeginn:
         type: string
         format: date
       sparPhase:
-        $ref: "#/definitions/SparPhase"
+        $ref: '#/definitions/SparPhase'
       tarif:
         type: string
         description: Tarifname
@@ -1283,7 +1286,7 @@ definitions:
         type: string
         description: Produktanbieter-spezifische Tarif-ID des Bauspartarifs
       tilgungsPhase:
-        $ref: "#/definitions/TilgungsPhase"
+        $ref: '#/definitions/TilgungsPhase'
       typ:
         type: string
       vertragsBeginn:
@@ -1295,7 +1298,7 @@ definitions:
         type: array
         description: "Liste von Antragstellern, die diesen Vertrag abschließen."
         items:
-          $ref: "#/definitions/AntragstellerVerknuepfung"
+          $ref: '#/definitions/AntragstellerVerknuepfung'
       verwaltungsgebuehrenJaehrlich:
         type: number
       zuteilungsDatum:
@@ -1312,22 +1315,22 @@ definitions:
         type: array
         description: Enthält die vom Produktanbieter anerkannten Beleihungswerte
         items:
-          $ref: "#/definitions/BeleihungsWert"
+          $ref: '#/definitions/BeleihungsWert'
       beleihungsWerteSumme:
         type: number
         description: "Berechnungshilfe: Die Summe aller vom Produktanbieter anerkannten Beleihungswerte"
       produktAnbieter:
-        $ref: "#/definitions/ProduktAnbieter"
+        $ref: '#/definitions/ProduktAnbieter'
     title: BeleihungsRechnung
   BeleihungsWert:
     type: object
     properties:
       adresse:
-        $ref: "#/definitions/Postadresse"
+        $ref: '#/definitions/Postadresse'
       beleihungsWert:
         type: number
       immobilie:
-        $ref: "#/definitions/ImmobilieVerknuepfung"
+        $ref: '#/definitions/ImmobilieVerknuepfung'
     title: BeleihungsWert
   Beratung:
     type: object
@@ -1335,9 +1338,9 @@ definitions:
       art:
         type: string
         enum:
-          - AUSSER_GESCHAEFTSRAUM_VERTRAG
-          - FERN_ABSATZ_GESCHAEFT
-          - PRAESENZ_GESCHAEFT
+        - AUSSER_GESCHAEFTSRAUM_VERTRAG
+        - FERN_ABSATZ_GESCHAEFT
+        - PRAESENZ_GESCHAEFT
       hinweisFuerProduktAnbieter:
         type: string
       istKundenBetreuerVerkaeuferOderMaklerDerImmobilie:
@@ -1373,8 +1376,8 @@ definitions:
         type: string
         description: "nur bei art==ANGESTELLTER,ARBEITER"
         enum:
-          - BEFRISTET
-          - UNBEFRISTET
+        - BEFRISTET
+        - UNBEFRISTET
       beruf:
         type: string
         description: nur bei art!=RENTNER
@@ -1393,7 +1396,7 @@ definitions:
         description: "nur bei art==ANGESTELLTER,ARBEITER,BEAMTER"
       situationNachRenteneintritt:
         description: nur bei art!=RENTNER
-        $ref: "#/definitions/SituationNachRenteneintritt"
+        $ref: '#/definitions/SituationNachRenteneintritt'
       sonstigesRegelmaessigesEinkommenNettoMonatlich:
         type: number
         description: "nur bei art==ARBEITSLOSER,HAUSFRAU"
@@ -1408,34 +1411,34 @@ definitions:
     type: object
     properties:
       adresse:
-        $ref: "#/definitions/Postadresse"
+        $ref: '#/definitions/Postadresse'
       autostellplaetze:
         type: array
         items:
-          $ref: "#/definitions/Autostellplatz"
+          $ref: '#/definitions/Autostellplatz'
       bestehendeDarlehen:
         type: array
         items:
-          $ref: "#/definitions/BestehendesDarlehen"
+          $ref: '#/definitions/BestehendesDarlehen'
       bodenRichtwert:
         type: number
         description: "Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt."
       erbbaurecht:
-        $ref: "#/definitions/Erbbaurecht"
+        $ref: '#/definitions/Erbbaurecht'
       gebaeude:
-        $ref: "#/definitions/Gebaeude"
+        $ref: '#/definitions/Gebaeude'
       grundbuchAngabe:
-        $ref: "#/definitions/GrundbuchAngabe"
+        $ref: '#/definitions/GrundbuchAngabe'
       grundstueck:
-        $ref: "#/definitions/Grundstueck"
+        $ref: '#/definitions/Grundstueck'
       id:
         type: string
       immobilienEinsatz:
         type: string
         enum:
-          - ALS_ZUSATZSICHERHEIT
-          - KEIN_EINSATZ
-          - VERKAUFEN
+        - ALS_ZUSATZSICHERHEIT
+        - KEIN_EINSATZ
+        - VERKAUFEN
       keinBaulandFlaecheInQm:
         type: number
         description: "Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt."
@@ -1447,9 +1450,9 @@ definitions:
       objektArt:
         type: string
         enum:
-          - EIGENTUMSWOHNUNG
-          - GRUNDSTUECK
-          - HAUS
+        - EIGENTUMSWOHNUNG
+        - GRUNDSTUECK
+        - HAUS
       vergleichsmieteFuerGewerbeflaecheProQm:
         type: number
         description: "Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt."
@@ -1482,11 +1485,11 @@ definitions:
       maximalAufzuloesenderBetrag:
         type: number
       produktAnbieter:
-        $ref: "#/definitions/ProduktAnbieter"
+        $ref: '#/definitions/ProduktAnbieter'
       sonderZahlungen:
         type: array
         items:
-          $ref: "#/definitions/SonderZahlung"
+          $ref: '#/definitions/SonderZahlung'
       sparBeitragMonatlich:
         type: number
       tarif:
@@ -1497,15 +1500,15 @@ definitions:
       vermoegensEinsatz:
         type: string
         enum:
-          - ABTRETEN
-          - AUFLOESEN
-          - KEIN_EINSATZ
+        - ABTRETEN
+        - AUFLOESEN
+        - KEIN_EINSATZ
       vermoegensTyp:
         type: string
         description: Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium
         enum:
-          - VERBINDLICHKEIT
-          - VERMOEGEN
+        - VERBINDLICHKEIT
+        - VERMOEGEN
       vertragsBeginn:
         type: string
         format: date
@@ -1517,8 +1520,8 @@ definitions:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-          - AUSGABE
-          - EINNAHME
+        - AUSGABE
+        - EINNAHME
       zuteilungsDatum:
         type: string
         format: date
@@ -1538,16 +1541,16 @@ definitions:
         type: string
         description: "Erlaubte Werte sind: BAUSPARDARLEHEN,FOERDERDARLEHEN,IMMOBILIENDARLEHEN,PRIVATDARLEHEN,SONSTIGES_DARLEHEN. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können."
         enum:
-          - BAUSPARDARLEHEN
-          - FOERDERDARLEHEN
-          - IMMOBILIENDARLEHEN
-          - PRIVATDARLEHEN
-          - SONSTIGES_DARLEHEN
+        - BAUSPARDARLEHEN
+        - FOERDERDARLEHEN
+        - IMMOBILIENDARLEHEN
+        - PRIVATDARLEHEN
+        - SONSTIGES_DARLEHEN
       darlehensBetrag:
         type: number
         description: "für Prolongation, d.h. technisch: Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG"
       darlehensGeber:
-        $ref: "#/definitions/ProduktAnbieter"
+        $ref: '#/definitions/ProduktAnbieter'
       darlehensKontonummer:
         type: string
         description: "für Prolongation, d.h. technisch: Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG"
@@ -1557,8 +1560,8 @@ definitions:
         type: string
         description: "Erlaubte Werte sind: BUCH_GRUNDSCHULD, BRIEF_GRUNDSCHULD. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können."
         enum:
-          - BRIEF_GRUNDSCHULD
-          - BUCH_GRUNDSCHULD
+        - BRIEF_GRUNDSCHULD
+        - BUCH_GRUNDSCHULD
       hauptKontonummerDslBank:
         type: string
         description: "für DSL Bank Prolongation, d.h. technisch: Produktanbieter ist 'DSL Bank' und Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG"
@@ -1602,16 +1605,16 @@ definitions:
         type: string
         description: "Erlaubte Werte sind: BAUSPARDARLEHEN,FOERDERDARLEHEN,IMMOBILIENDARLEHEN,PRIVATDARLEHEN,SONSTIGES_DARLEHEN. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können."
         enum:
-          - BAUSPARDARLEHEN
-          - FOERDERDARLEHEN
-          - IMMOBILIENDARLEHEN
-          - PRIVATDARLEHEN
-          - SONSTIGES_DARLEHEN
+        - BAUSPARDARLEHEN
+        - FOERDERDARLEHEN
+        - IMMOBILIENDARLEHEN
+        - PRIVATDARLEHEN
+        - SONSTIGES_DARLEHEN
       darlehensBetrag:
         type: number
         description: "für Prolongation, d.h. technisch: Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG"
       darlehensGeber:
-        $ref: "#/definitions/ProduktAnbieter"
+        $ref: '#/definitions/ProduktAnbieter'
       darlehensKontonummer:
         type: string
         description: "für Prolongation, d.h. technisch: Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG"
@@ -1621,8 +1624,8 @@ definitions:
         type: string
         description: "Erlaubte Werte sind: BUCH_GRUNDSCHULD, BRIEF_GRUNDSCHULD. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können."
         enum:
-          - BRIEF_GRUNDSCHULD
-          - BUCH_GRUNDSCHULD
+        - BRIEF_GRUNDSCHULD
+        - BUCH_GRUNDSCHULD
       hauptKontonummerDslBank:
         type: string
         description: "für DSL Bank Prolongation, d.h. technisch: Produktanbieter ist 'DSL Bank' und Vorhaben verwendungszweck==ANSCHLUSSFINANZIERUNG"
@@ -1648,9 +1651,9 @@ definitions:
         type: string
         description: "Beschreibt wie das Darlehen im Zusammenhang mit dem Vorhaben, behandelt werden soll."
         enum:
-          - ABLOESEN
-          - TRITT_IM_RANG_ZURUECK
-          - TRITT_NICHT_IM_RANG_ZURUECK
+        - ABLOESEN
+        - TRITT_IM_RANG_ZURUECK
+        - TRITT_NICHT_IM_RANG_ZURUECK
       wirdAbgeloest:
         type: boolean
         description: "true, wenn Darlehen abgelöst wird, ansonsten false"
@@ -1677,11 +1680,11 @@ definitions:
       haushaltsUeberschuss:
         type: number
       kreditEntscheider:
-        $ref: "#/definitions/ProduktAnbieter"
+        $ref: '#/definitions/ProduktAnbieter'
       nebenkostenAllerEigengenutzterWohnflaechen:
         type: number
       produktAnbieter:
-        $ref: "#/definitions/ProduktAnbieter"
+        $ref: '#/definitions/ProduktAnbieter'
     title: Bonitaet
   Branche:
     type: object
@@ -1689,9 +1692,9 @@ definitions:
       typ:
         type: string
         enum:
-          - ING
-          - MHB
-          - S_RATING
+        - ING
+        - MHB
+        - S_RATING
       wert:
         type: string
         description: "Kann je nach Typ folgende Ausprägungen besitzen.\n\nFür Ausprägung ING erlaubte Werte: BANKEN_VERSICHERUNGEN, BAUGEWERBE, DIENSTLEISTUNGEN_SONSTIGE, EDV_BERATUNG, ENERGIE, ERZIEHUNG_UNTERRICHT, GESUNDHEITSWESEN, HANDEL, HANDWERK, HOTEL_GASTRONOMIE, LANDWIRTSCHAFT, OEFFENTLICHER_DIENST, PRODUKTION_INDUSTRIE, VERKEHR\n\nFür Ausprägung MHB erlaubte Werte: VERARBEITENDES_GEWERBE, BAU, HANDEL, VERKEHR_INFORMATION, DIENSTLEISTUNG, SONSTIGES\n\nFür Ausprägung S_RATING erlaubte Werte: BAUGEWERBE, DIENSTLEISTUNGEN, ENERGIE_UND_WASSERVERSORGUNG_BERGBAU, GEBIETSKOERPERSCHAFTEN_UND_SOZIALVERSICHERUNGEN, GESUNDHEITSWESEN, HANDEL, HOTEL_UND_GASTRONOMIE, KREDITINSTITUTE, LAND_UND_FORSTWIRTSCHAFT_FISCHEREI, OEFFENTLICHER_DIENST, ORGANISATIONEN_OHNE_ERWERBSZWECK_PRIVATE_HAUSHALTE, VERARBEITENDES_GEWERBE, VERKEHR_UND_NACHRICHTENUEBERMITTLUNG, VERSICHERUNGEN, SONSTIGE"
@@ -1711,26 +1714,26 @@ definitions:
         type: string
       bereitstellung:
         description: nicht bei darlehensTyp==PRIVAT_DARLEHEN
-        $ref: "#/definitions/Bereitstellung"
+        $ref: '#/definitions/Bereitstellung'
       darlehensBetrag:
         type: number
       darlehensTyp:
         type: string
         enum:
-          - ANNUITAETEN_DARLEHEN
-          - FORWARD_DARLEHEN
-          - KFW_DARLEHEN
-          - PRIVAT_DARLEHEN
-          - REGIONAL_FOERDER_DARLEHEN
-          - VARIABLES_DARLEHEN
-          - ZWISCHEN_FINANZIERUNG
+        - ANNUITAETEN_DARLEHEN
+        - FORWARD_DARLEHEN
+        - KFW_DARLEHEN
+        - PRIVAT_DARLEHEN
+        - REGIONAL_FOERDER_DARLEHEN
+        - VARIABLES_DARLEHEN
+        - ZWISCHEN_FINANZIERUNG
       detailsZurVerwendung:
         type: string
         description: nur bei darlehensTyp==ZWISCHEN_FINANZIERUNG
       effektivZins:
         type: number
       effektivZinsRelevanteKosten:
-        $ref: "#/definitions/EffektivZinsKosten"
+        $ref: '#/definitions/EffektivZinsKosten'
       einstandsDatum:
         type: string
         format: date-time
@@ -1778,9 +1781,9 @@ definitions:
         format: int32
         description: nur bei darlehensTyp==ZWISCHEN_FINANZIERUNG
       produktAnbieter:
-        $ref: "#/definitions/ProduktAnbieter"
+        $ref: '#/definitions/ProduktAnbieter'
       provision:
-        $ref: "#/definitions/Provision"
+        $ref: '#/definitions/Provision'
       rateMonatlich:
         type: number
         example: 123.34
@@ -1797,7 +1800,7 @@ definitions:
         description: Der Sollzinssatz in Prozent
       tilgung:
         description: nicht bei darlehensTyp==ZWISCHEN_FINANZIERUNG
-        $ref: "#/definitions/Tilgung"
+        $ref: '#/definitions/Tilgung'
       tilgungsFreieAnlaufJahre:
         type: integer
         format: int32
@@ -1806,12 +1809,12 @@ definitions:
         type: string
         description: nur bei darlehensTyp==ZWISCHEN_FINANZIERUNG
         enum:
-          - SONSTIGE_VERWENDUNG
-          - VERKAUF_EINES_ANDEREN_OBJEKTS
-          - VORFINANZIERUNG_OEFFENTLICHER_MITTEL
+        - SONSTIGE_VERWENDUNG
+        - VERKAUF_EINES_ANDEREN_OBJEKTS
+        - VORFINANZIERUNG_OEFFENTLICHER_MITTEL
       zinsBindung:
         description: "nicht bei darlehensTyp IN [VARIABLES_DARLEHEN,ZWISCHEN_FINANZIERUNG]"
-        $ref: "#/definitions/ZinsBindung"
+        $ref: '#/definitions/ZinsBindung'
       zinsZahlungsBeginnAm:
         type: string
         format: date
@@ -1833,7 +1836,7 @@ definitions:
         description: Name des Dokuments
       type:
         type: string
-        description: 'Mediatype des Dokuments, siehe <a href="http://tools.ietf.org/html/rfc7231#section-3.1.1.1">HTTP 1.1: Semantics and Content, section 3.1.1.1</a>'
+        description: "Mediatype des Dokuments, siehe <a href=\"http://tools.ietf.org/html/rfc7231#section-3.1.1.1\">HTTP 1.1: Semantics and Content, section 3.1.1.1</a>"
     title: Dokument
   EffektivZinsKosten:
     type: object
@@ -1867,8 +1870,8 @@ definitions:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-          - AUSGABE
-          - EINNAHME
+        - AUSGABE
+        - EINNAHME
     title: EinkuenfteAusNebentaetigkeit
   EinnahmenMonatlich:
     type: object
@@ -1879,8 +1882,8 @@ definitions:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-          - AUSGABE
-          - EINNAHME
+        - AUSGABE
+        - EINNAHME
     title: EinnahmenMonatlich
   Eintrag:
     type: object
@@ -1903,16 +1906,16 @@ definitions:
       typ:
         type: string
         enum:
-          - AGGREGIERTER_EINTRAG
-          - EINTRAG
-          - SUMMEN_EINTRAG_ZUM_ZINSBINDUNGSENDE
+        - AGGREGIERTER_EINTRAG
+        - EINTRAG
+        - SUMMEN_EINTRAG_ZUM_ZINSBINDUNGSENDE
       zahlung:
         type: number
       zahlungsTyp:
         type: string
         enum:
-          - AUSZAHLUNG
-          - EINZAHLUNG
+        - AUSZAHLUNG
+        - EINZAHLUNG
       zinsen:
         type: number
     title: Eintrag
@@ -1924,8 +1927,8 @@ definitions:
       grundstuecksEigentuemer:
         type: string
         enum:
-          - ANDERE
-          - OEFFENTLICH_KIRCHLICH
+        - ANDERE
+        - OEFFENTLICH_KIRCHLICH
       laufzeitBisJahr:
         type: string
         example: "2016"
@@ -1993,26 +1996,26 @@ definitions:
     type: object
     properties:
       adresse:
-        $ref: "#/definitions/Postadresse"
+        $ref: '#/definitions/Postadresse'
       autostellplaetze:
         type: array
         items:
-          $ref: "#/definitions/Autostellplatz"
+          $ref: '#/definitions/Autostellplatz'
       bestehendeDarlehen:
         type: array
         items:
-          $ref: "#/definitions/BestehendesDarlehenDesFinanzierungsObjekts"
+          $ref: '#/definitions/BestehendesDarlehenDesFinanzierungsObjekts'
       bodenRichtwert:
         type: number
         description: "Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt."
       erbbaurecht:
-        $ref: "#/definitions/Erbbaurecht"
+        $ref: '#/definitions/Erbbaurecht'
       gebaeude:
-        $ref: "#/definitions/Gebaeude"
+        $ref: '#/definitions/Gebaeude'
       grundbuchAngabe:
-        $ref: "#/definitions/GrundbuchAngabe"
+        $ref: '#/definitions/GrundbuchAngabe'
       grundstueck:
-        $ref: "#/definitions/Grundstueck"
+        $ref: '#/definitions/Grundstueck'
       id:
         type: string
       keinBaulandFlaecheInQm:
@@ -2024,9 +2027,9 @@ definitions:
       objektArt:
         type: string
         enum:
-          - EIGENTUMSWOHNUNG
-          - GRUNDSTUECK
-          - HAUS
+        - EIGENTUMSWOHNUNG
+        - GRUNDSTUECK
+        - HAUS
       vergleichsmieteFuerGewerbeflaecheProQm:
         type: number
         description: "Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt."
@@ -2047,7 +2050,7 @@ definitions:
     type: object
     properties:
       anteil:
-        $ref: "#/definitions/MiteigentumsAnteil"
+        $ref: '#/definitions/MiteigentumsAnteil'
       flur:
         type: string
       flurstuecksNummer:
@@ -2058,71 +2061,71 @@ definitions:
   ForwardDarlehen:
     title: ForwardDarlehen
     allOf:
-      - $ref: "#/definitions/GegenangebotDarlehen"
-      - type: object
-        required:
-          - anfaenglicheTilgung
-          - bereitstellungsZinsFreieZeitInMonaten
-          - darlehensBetrag
-          - darlehensTyp
-          - effektivZins
-          - forwardPeriodeInMonaten
-          - laufzeitKalkulatorischInJahren
-          - rateMonatlich
-          - sollZins
-          - sonderTilgungJaehrlich
-          - vertriebsProvisionGesamtAbsolut
-          - zinsBindungInJahren
-        discriminator: darlehensTyp
-        properties:
-          anfaenglicheTilgung:
-            type: number
-          bereitstellungsZins:
-            type: number
-          bereitstellungsZinsFreieZeitInMonaten:
-            type: integer
-            format: int32
-          darlehensBetrag:
-            type: number
-          darlehensTyp:
-            type: string
-            enum:
-              - ANNUITAETEN_DARLEHEN
-              - FORWARD_DARLEHEN
-              - KFW_DARLEHEN
-              - PRIVAT_DARLEHEN
-              - REGIONAL_FOERDER_DARLEHEN
-              - VARIABLES_DARLEHEN
-              - ZWISCHEN_FINANZIERUNG
-          effektivZins:
-            type: number
-          forwardPeriodeInMonaten:
-            type: integer
-            format: int32
-          laufzeitKalkulatorischInJahren:
-            type: integer
-            format: int32
-          produktDetails:
-            type: string
-            description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
-          rateMonatlich:
-            type: number
-          sollZins:
-            type: number
-          sonderTilgungJaehrlich:
-            type: number
-          tilgungsBeginnAm:
-            type: string
-            format: date-time
-            example: 2020-03-28
-          vertriebsProvisionGesamtAbsolut:
-            type: number
-            description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
-          zinsBindungInJahren:
-            type: integer
-            format: int32
-        title: ForwardDarlehen
-        description: Erweitert GegenangebotDarlehen
+    - $ref: '#/definitions/GegenangebotDarlehen'
+    - type: object
+      required:
+      - anfaenglicheTilgung
+      - bereitstellungsZinsFreieZeitInMonaten
+      - darlehensBetrag
+      - darlehensTyp
+      - effektivZins
+      - forwardPeriodeInMonaten
+      - laufzeitKalkulatorischInJahren
+      - rateMonatlich
+      - sollZins
+      - sonderTilgungJaehrlich
+      - vertriebsProvisionGesamtAbsolut
+      - zinsBindungInJahren
+      discriminator: darlehensTyp
+      properties:
+        anfaenglicheTilgung:
+          type: number
+        bereitstellungsZins:
+          type: number
+        bereitstellungsZinsFreieZeitInMonaten:
+          type: integer
+          format: int32
+        darlehensBetrag:
+          type: number
+        darlehensTyp:
+          type: string
+          enum:
+          - ANNUITAETEN_DARLEHEN
+          - FORWARD_DARLEHEN
+          - KFW_DARLEHEN
+          - PRIVAT_DARLEHEN
+          - REGIONAL_FOERDER_DARLEHEN
+          - VARIABLES_DARLEHEN
+          - ZWISCHEN_FINANZIERUNG
+        effektivZins:
+          type: number
+        forwardPeriodeInMonaten:
+          type: integer
+          format: int32
+        laufzeitKalkulatorischInJahren:
+          type: integer
+          format: int32
+        produktDetails:
+          type: string
+          description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
+        rateMonatlich:
+          type: number
+        sollZins:
+          type: number
+        sonderTilgungJaehrlich:
+          type: number
+        tilgungsBeginnAm:
+          type: string
+          format: date-time
+          example: 2020-03-28
+        vertriebsProvisionGesamtAbsolut:
+          type: number
+          description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
+        zinsBindungInJahren:
+          type: integer
+          format: int32
+      title: ForwardDarlehen
+      description: Erweitert GegenangebotDarlehen
     description: Erweitert GegenangebotDarlehen
   Gebaeude:
     type: object
@@ -2157,22 +2160,22 @@ definitions:
         type: boolean
         description: Nur bei ObjektArt == HAUS.
       gewerbeflaeche:
-        $ref: "#/definitions/GebaeudeFlaeche"
+        $ref: '#/definitions/GebaeudeFlaeche'
       hausAnordnung:
         type: string
         enum:
-          - FREISTEHEND
-          - KOPFHAUS
-          - MITTELHAUS
+        - FREISTEHEND
+        - KOPFHAUS
+        - MITTELHAUS
       hausTyp:
         type: string
         description: Nur bei ObjektArt == HAUS.
         enum:
-          - DOPPELHAUSHAELFTE
-          - EINFAMILIENHAUS
-          - MEHRFAMILIENHAUS
-          - REIHENHAUS
-          - ZWEIFAMILIENHAUS
+        - DOPPELHAUSHAELFTE
+        - EINFAMILIENHAUS
+        - MEHRFAMILIENHAUS
+        - REIHENHAUS
+        - ZWEIFAMILIENHAUS
       istFertighaus:
         type: boolean
         description: Nur bei ObjektArt == HAUS.
@@ -2181,29 +2184,29 @@ definitions:
         description: "Angabe in Kubikmetern. Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt."
       miteigentumsAnteil:
         description: Nur bei ObjektArt == EIGENTUMSWOHNUNG.
-        $ref: "#/definitions/MiteigentumsAnteil"
+        $ref: '#/definitions/MiteigentumsAnteil'
       modernisierungen:
         type: array
         description: "Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt."
         items:
-          $ref: "#/definitions/Modernisierung"
+          $ref: '#/definitions/Modernisierung'
       modernisierungsAngaben:
         description: Deprecated. Zukünftig wird die Liste Modernisierungen verwendet.
-        $ref: "#/definitions/ModernisierungsAngaben"
+        $ref: '#/definitions/ModernisierungsAngaben'
       unterkellerung:
         type: string
         description: "Nur bei ObjektArt == HAUS. Erlaubte Werte sind: NICHT_UNTERKELLERT,TEILWEISE_UNTERKELLERT,UNTERKELLERT. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können."
       wohnflaeche:
-        $ref: "#/definitions/GebaeudeFlaeche"
+        $ref: '#/definitions/GebaeudeFlaeche'
       zustand:
         type: string
         description: Angaben zum Zustand der Immobilie für die automatische Objektbewertungs-Schnittstelle (VDP)
         enum:
-          - GUT
-          - MAESSIG
-          - MITTEL
-          - SCHLECHT
-          - SEHR_GUT
+        - GUT
+        - MAESSIG
+        - MITTEL
+        - SCHLECHT
+        - SEHR_GUT
     title: Gebaeude
   GebaeudeFlaeche:
     type: object
@@ -2211,17 +2214,17 @@ definitions:
       gesamtGroesse:
         type: number
       vermietungsInformationen:
-        $ref: "#/definitions/VermietungsInformationen"
+        $ref: '#/definitions/VermietungsInformationen'
     title: GebaeudeFlaeche
   Gegenangebot:
     type: object
     required:
-      - darlehen
+    - darlehen
     properties:
       darlehen:
         type: array
         items:
-          $ref: "#/definitions/GegenangebotDarlehen"
+          $ref: '#/definitions/GegenangebotDarlehen'
       kennung:
         type: string
         description: Anmerkung des Angebots in der Ergebnisliste - sichtbar für den Vertrieb.
@@ -2229,13 +2232,13 @@ definitions:
   GegenangebotDarlehen:
     type: object
     required:
-      - anfaenglicheTilgung
-      - darlehensBetrag
-      - darlehensTyp
-      - effektivZins
-      - rateMonatlich
-      - sollZins
-      - vertriebsProvisionGesamtAbsolut
+    - anfaenglicheTilgung
+    - darlehensBetrag
+    - darlehensTyp
+    - effektivZins
+    - rateMonatlich
+    - sollZins
+    - vertriebsProvisionGesamtAbsolut
     discriminator: darlehensTyp
     properties:
       anfaenglicheTilgung:
@@ -2245,13 +2248,13 @@ definitions:
       darlehensTyp:
         type: string
         enum:
-          - ANNUITAETEN_DARLEHEN
-          - FORWARD_DARLEHEN
-          - KFW_DARLEHEN
-          - PRIVAT_DARLEHEN
-          - REGIONAL_FOERDER_DARLEHEN
-          - VARIABLES_DARLEHEN
-          - ZWISCHEN_FINANZIERUNG
+        - ANNUITAETEN_DARLEHEN
+        - FORWARD_DARLEHEN
+        - KFW_DARLEHEN
+        - PRIVAT_DARLEHEN
+        - REGIONAL_FOERDER_DARLEHEN
+        - VARIABLES_DARLEHEN
+        - ZWISCHEN_FINANZIERUNG
       effektivZins:
         type: number
       produktDetails:
@@ -2280,13 +2283,13 @@ definitions:
       flurstuecke:
         type: array
         items:
-          $ref: "#/definitions/Flurstueck"
+          $ref: '#/definitions/Flurstueck'
       ort:
         type: string
         description: Ort des als Grundbuchamt zuständigen Amtsgerichtes
       rechteInAbteilung2:
         description: "Belastungen und Beschränkungen in der Nutzbarkeit des Grundstücks. Leitungsrechte, Verzichte auf Abstandsflächen, Wegerechte, Insolvenzvermerke."
-        $ref: "#/definitions/RechteAbteilung2"
+        $ref: '#/definitions/RechteAbteilung2'
     title: GrundbuchAngabe
   Grundstueck:
     type: object
@@ -2296,11 +2299,11 @@ definitions:
       grundstuecksArt:
         type: string
         enum:
-          - LANDWIRTSCHAFTLICHES_GRUNDSTUECK
-          - SONSTIGES_GRUNDSTUECK
-          - UNBEBAUTES_GEWERBEGRUNDSTUECK
-          - UNBEBAUTES_MISCHGRUNDSTUECK
-          - UNBEBAUTES_WOHNGRUNDSTUECK
+        - LANDWIRTSCHAFTLICHES_GRUNDSTUECK
+        - SONSTIGES_GRUNDSTUECK
+        - UNBEBAUTES_GEWERBEGRUNDSTUECK
+        - UNBEBAUTES_MISCHGRUNDSTUECK
+        - UNBEBAUTES_WOHNGRUNDSTUECK
     title: Grundstueck
   Haushalt:
     type: object
@@ -2308,7 +2311,7 @@ definitions:
       antragsteller:
         type: array
         items:
-          $ref: "#/definitions/Antragsteller"
+          $ref: '#/definitions/Antragsteller'
       anzahlErwachseneImHaushalt:
         type: integer
         format: int32
@@ -2320,7 +2323,7 @@ definitions:
       bestehendeImmobilien:
         type: array
         items:
-          $ref: "#/definitions/BestehendeImmobilie"
+          $ref: '#/definitions/BestehendeImmobilie'
       id:
         type: string
       kfzAnzahl:
@@ -2330,14 +2333,14 @@ definitions:
       kinder:
         type: array
         items:
-          $ref: "#/definitions/Kind"
+          $ref: '#/definitions/Kind'
       lebenshaltungsKostenMonatlich:
         type: number
         description: "Diese Angabe ist produktanbieterspezifisch, sie wird nicht von allen Produktanbietern bei der Angebotsermittlung berücksichtigt. (DSL Bank)"
       obligo:
-        $ref: "#/definitions/VermoegenVerbindlichkeiten"
+        $ref: '#/definitions/VermoegenVerbindlichkeiten'
       positionen:
-        $ref: "#/definitions/HaushaltsPositionen"
+        $ref: '#/definitions/HaushaltsPositionen'
     title: Haushalt
   HaushaltsPositionen:
     type: object
@@ -2345,84 +2348,84 @@ definitions:
       bankUndSparguthaben:
         type: array
         items:
-          $ref: "#/definitions/BankUndSparguthaben"
+          $ref: '#/definitions/BankUndSparguthaben'
       bausparvertraege:
         type: array
         items:
-          $ref: "#/definitions/BestehenderBausparvertrag"
+          $ref: '#/definitions/BestehenderBausparvertrag'
       ehegattenUnterhalt:
         type: array
         items:
-          $ref: "#/definitions/EinnahmenMonatlich"
+          $ref: '#/definitions/EinnahmenMonatlich'
       einkuenfteAusNebentaetigkeit:
         type: array
         items:
-          $ref: "#/definitions/EinkuenfteAusNebentaetigkeit"
+          $ref: '#/definitions/EinkuenfteAusNebentaetigkeit'
       kindergeld:
         type: array
         description: Read-Only-Feld. Wird dynamisch aus den Angaben zu den Kindern berechnet. Pro kindergelderhaltendem Kind ein Listenelement.
         items:
-          $ref: "#/definitions/EinnahmenMonatlich"
+          $ref: '#/definitions/EinnahmenMonatlich'
       lebensUndRentenVersicherungen:
         type: array
         items:
-          $ref: "#/definitions/LebensOderRentenversicherungVermoegen"
+          $ref: '#/definitions/LebensOderRentenversicherungVermoegen'
       mietAusgaben:
         type: array
         items:
-          $ref: "#/definitions/MietAusgaben"
+          $ref: '#/definitions/MietAusgaben'
       privateDarlehen:
         type: array
         items:
-          $ref: "#/definitions/Verbindlichkeit"
+          $ref: '#/definitions/Verbindlichkeit'
       privateKrankenversicherung:
         type: array
         items:
-          $ref: "#/definitions/AusgabenMonatlich"
+          $ref: '#/definitions/AusgabenMonatlich'
       ratenkredite:
         type: array
         items:
-          $ref: "#/definitions/Verbindlichkeit"
+          $ref: '#/definitions/Verbindlichkeit'
       sonstigeAusgaben:
         type: array
         items:
-          $ref: "#/definitions/AusgabenMonatlich"
+          $ref: '#/definitions/AusgabenMonatlich'
       sonstigeEinnahmen:
         type: array
         items:
-          $ref: "#/definitions/EinnahmenMonatlich"
+          $ref: '#/definitions/EinnahmenMonatlich'
       sonstigeVerbindlichkeiten:
         type: array
         items:
-          $ref: "#/definitions/Verbindlichkeit"
+          $ref: '#/definitions/Verbindlichkeit'
       sonstigeVermoegen:
         type: array
         items:
-          $ref: "#/definitions/Vermoegen"
+          $ref: '#/definitions/Vermoegen'
       sparplaene:
         type: array
         items:
-          $ref: "#/definitions/Sparplaene"
+          $ref: '#/definitions/Sparplaene'
       unbefristeteZusatzRenten:
         type: array
         items:
-          $ref: "#/definitions/EinnahmenMonatlich"
+          $ref: '#/definitions/EinnahmenMonatlich'
       unterhaltsVerpflichtungen:
         type: array
         items:
-          $ref: "#/definitions/AusgabenMonatlich"
+          $ref: '#/definitions/AusgabenMonatlich'
       variableEinkuenfte:
         type: array
         items:
-          $ref: "#/definitions/EinnahmenMonatlich"
+          $ref: '#/definitions/EinnahmenMonatlich'
       versicherungsAusgaben:
         type: array
         items:
-          $ref: "#/definitions/AusgabenMonatlich"
+          $ref: '#/definitions/AusgabenMonatlich'
       wertpapiere:
         type: array
         items:
-          $ref: "#/definitions/Wertpapiere"
+          $ref: '#/definitions/Wertpapiere'
     title: HaushaltsPositionen
   ImmobilieVerknuepfung:
     type: object
@@ -2433,107 +2436,107 @@ definitions:
   KfwDarlehen:
     title: KfwDarlehen
     allOf:
-      - $ref: "#/definitions/GegenangebotDarlehen"
-      - type: object
-        required:
-          - anfaenglicheTilgung
-          - bereitstellungsZins
-          - bereitstellungsZinsFreieZeitInMonaten
-          - darlehensBetrag
-          - darlehensTyp
-          - effektivZins
-          - kfwProgramm
-          - laufzeitKalkulatorischInJahren
-          - rateMonatlich
-          - rateMonatlichInDerTilgungsfreienAnlaufzeit
-          - sollZins
-          - tilgungsFreieAnlaufJahre
-          - vertriebsProvisionGesamtAbsolut
-          - zinsBindungInJahren
-        discriminator: darlehensTyp
-        properties:
-          anfaenglicheTilgung:
-            type: number
-          bereitstellungsZins:
-            type: number
-          bereitstellungsZinsFreieZeitInMonaten:
-            type: integer
-            format: int32
-          darlehensBetrag:
-            type: number
-          darlehensTyp:
-            type: string
-            enum:
-              - ANNUITAETEN_DARLEHEN
-              - FORWARD_DARLEHEN
-              - KFW_DARLEHEN
-              - PRIVAT_DARLEHEN
-              - REGIONAL_FOERDER_DARLEHEN
-              - VARIABLES_DARLEHEN
-              - ZWISCHEN_FINANZIERUNG
-          effektivZins:
-            type: number
-          kfwEnergieEffizienzGruppe:
-            type: string
-            description: "Nur benötigt, wenn kfwProgramm = PROGRAMM_261, PROGRAMM_262"
-            enum:
-              - NEUBAU
-              - SANIERUNG
-              - STANDARD
-          kfwEnergieEffizienzStandard:
-            type: string
-            description: "Nur benötigt, wenn kfwProgramm = PROGRAMM_153, PROGRAMM_261, PROGRAMM_262"
-            enum:
-              - STANDARD_100
-              - STANDARD_100_EEK
-              - STANDARD_40
-              - STANDARD_40_EEK
-              - STANDARD_40_PLUS
-              - STANDARD_55
-              - STANDARD_55_EEK
-              - STANDARD_70
-              - STANDARD_70_EEK
-              - STANDARD_85
-              - STANDARD_85_EEK
-              - STANDARD_DENKMAL
-              - STANDARD_DENKMAL_EEK
-          kfwProgramm:
-            type: string
-            enum:
-              - PROGRAMM_124
-              - PROGRAMM_151
-              - PROGRAMM_152
-              - PROGRAMM_153
-              - PROGRAMM_159
-              - PROGRAMM_167
-              - PROGRAMM_261
-              - PROGRAMM_262
-          kfwSanierungsFahrplanLiegtVor:
-            type: boolean
-            description: "Nur benötigt, wenn kfwProgramm = PROGRAMM_261, PROGRAMM_262"
-          laufzeitKalkulatorischInJahren:
-            type: integer
-            format: int32
-          produktDetails:
-            type: string
-            description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
-          rateMonatlich:
-            type: number
-          rateMonatlichInDerTilgungsfreienAnlaufzeit:
-            type: number
-          sollZins:
-            type: number
-          tilgungsFreieAnlaufJahre:
-            type: integer
-            format: int32
-          vertriebsProvisionGesamtAbsolut:
-            type: number
-            description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
-          zinsBindungInJahren:
-            type: integer
-            format: int32
-        title: KfwDarlehen
-        description: Erweitert GegenangebotDarlehen
+    - $ref: '#/definitions/GegenangebotDarlehen'
+    - type: object
+      required:
+      - anfaenglicheTilgung
+      - bereitstellungsZins
+      - bereitstellungsZinsFreieZeitInMonaten
+      - darlehensBetrag
+      - darlehensTyp
+      - effektivZins
+      - kfwProgramm
+      - laufzeitKalkulatorischInJahren
+      - rateMonatlich
+      - rateMonatlichInDerTilgungsfreienAnlaufzeit
+      - sollZins
+      - tilgungsFreieAnlaufJahre
+      - vertriebsProvisionGesamtAbsolut
+      - zinsBindungInJahren
+      discriminator: darlehensTyp
+      properties:
+        anfaenglicheTilgung:
+          type: number
+        bereitstellungsZins:
+          type: number
+        bereitstellungsZinsFreieZeitInMonaten:
+          type: integer
+          format: int32
+        darlehensBetrag:
+          type: number
+        darlehensTyp:
+          type: string
+          enum:
+          - ANNUITAETEN_DARLEHEN
+          - FORWARD_DARLEHEN
+          - KFW_DARLEHEN
+          - PRIVAT_DARLEHEN
+          - REGIONAL_FOERDER_DARLEHEN
+          - VARIABLES_DARLEHEN
+          - ZWISCHEN_FINANZIERUNG
+        effektivZins:
+          type: number
+        kfwEnergieEffizienzGruppe:
+          type: string
+          description: "Nur benötigt, wenn kfwProgramm = PROGRAMM_261, PROGRAMM_262"
+          enum:
+          - NEUBAU
+          - SANIERUNG
+          - STANDARD
+        kfwEnergieEffizienzStandard:
+          type: string
+          description: "Nur benötigt, wenn kfwProgramm = PROGRAMM_153, PROGRAMM_261, PROGRAMM_262"
+          enum:
+          - STANDARD_100
+          - STANDARD_100_EEK
+          - STANDARD_40
+          - STANDARD_40_EEK
+          - STANDARD_40_PLUS
+          - STANDARD_55
+          - STANDARD_55_EEK
+          - STANDARD_70
+          - STANDARD_70_EEK
+          - STANDARD_85
+          - STANDARD_85_EEK
+          - STANDARD_DENKMAL
+          - STANDARD_DENKMAL_EEK
+        kfwProgramm:
+          type: string
+          enum:
+          - PROGRAMM_124
+          - PROGRAMM_151
+          - PROGRAMM_152
+          - PROGRAMM_153
+          - PROGRAMM_159
+          - PROGRAMM_167
+          - PROGRAMM_261
+          - PROGRAMM_262
+        kfwSanierungsFahrplanLiegtVor:
+          type: boolean
+          description: "Nur benötigt, wenn kfwProgramm = PROGRAMM_261, PROGRAMM_262"
+        laufzeitKalkulatorischInJahren:
+          type: integer
+          format: int32
+        produktDetails:
+          type: string
+          description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
+        rateMonatlich:
+          type: number
+        rateMonatlichInDerTilgungsfreienAnlaufzeit:
+          type: number
+        sollZins:
+          type: number
+        tilgungsFreieAnlaufJahre:
+          type: integer
+          format: int32
+        vertriebsProvisionGesamtAbsolut:
+          type: number
+          description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
+        zinsBindungInJahren:
+          type: integer
+          format: int32
+      title: KfwDarlehen
+      description: Erweitert GegenangebotDarlehen
     description: Erweitert GegenangebotDarlehen
   KfwKonditionsReservierung:
     type: object
@@ -2582,23 +2585,23 @@ definitions:
       typ:
         type: string
         enum:
-          - FONDSGEBUNDENE_LEBENSVERSICHERUNG
-          - FONDSGEBUNDENE_RENTENVERSICHERUNG
-          - KAPITALBILDENDE_LEBENSVERSICHERUNG
-          - KAPITALBILDENDE_RENTENVERSICHERUNG
-          - RISIKO_LEBENSVERSICHERUNG
+        - FONDSGEBUNDENE_LEBENSVERSICHERUNG
+        - FONDSGEBUNDENE_RENTENVERSICHERUNG
+        - KAPITALBILDENDE_LEBENSVERSICHERUNG
+        - KAPITALBILDENDE_RENTENVERSICHERUNG
+        - RISIKO_LEBENSVERSICHERUNG
       vermoegensEinsatz:
         type: string
         enum:
-          - ABTRETEN
-          - AUFLOESEN
-          - KEIN_EINSATZ
+        - ABTRETEN
+        - AUFLOESEN
+        - KEIN_EINSATZ
       vermoegensTyp:
         type: string
         description: Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium
         enum:
-          - VERBINDLICHKEIT
-          - VERMOEGEN
+        - VERBINDLICHKEIT
+        - VERMOEGEN
       versicherungsGesellschaft:
         type: string
       versicherungsSumme:
@@ -2617,8 +2620,8 @@ definitions:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-          - AUSGABE
-          - EINNAHME
+        - AUSGABE
+        - EINNAHME
     title: LebensOderRentenversicherungVermoegen
   LegitimationsDaten:
     type: object
@@ -2631,9 +2634,9 @@ definitions:
       ausweisArt:
         type: string
         enum:
-          - ANDERE
-          - PERSONALAUSWEIS
-          - REISEPASS
+        - ANDERE
+        - PERSONALAUSWEIS
+        - REISEPASS
       ausweisArtBeiAndererAusweis:
         type: string
         description: Nur wenn ausweisArt = ANDERE
@@ -2652,7 +2655,7 @@ definitions:
     type: object
     properties:
       self:
-        $ref: "#/definitions/Link"
+        $ref: '#/definitions/Link'
     title: Links
   Meldung:
     type: object
@@ -2661,9 +2664,9 @@ definitions:
         type: string
         description: "Mögliche Werte sind: AUSZAHLUNGS_VORAUSSETZUNG,MACHBAR,MACHBARKEITS_HINWEIS,ANPASSUNG_KUNDENWUNSCH,ANPASSUNG_VERTRIEBSWUNSCH,UNBERUECKSICHTIGTE_ANGABE,KONDITIONEN_UNTER_VORBEHALT_VOLLSTAENDIGER_DATEN,KONDITIONEN_UNTER_VORBEHALT_EXTERNER_SCHNITTSTELLEN,MACHBARKEIT_UNTER_VORBEHALT_VOLLSTAENDIGER_DATEN,MACHBARKEIT_UNTER_VORBEHALT_EXTERNER_SCHNITTSTELLEN,MACHBAR_UNTER_VORBEHALT_PRODUZENT,NICHT_MACHBAR,NICHT_ANBIETBAR. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können."
       kreditEntscheider:
-        $ref: "#/definitions/ProduktAnbieter"
+        $ref: '#/definitions/ProduktAnbieter'
       produktAnbieter:
-        $ref: "#/definitions/ProduktAnbieter"
+        $ref: '#/definitions/ProduktAnbieter'
       text:
         type: string
     title: Meldung
@@ -2678,8 +2681,8 @@ definitions:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-          - AUSGABE
-          - EINNAHME
+        - AUSGABE
+        - EINNAHME
     title: MietAusgaben
   MiteigentumsAnteil:
     type: object
@@ -2700,23 +2703,23 @@ definitions:
         type: string
         description: "Erlaubte Werte sind: UEBERWIEGEND,UMFASSEND,MITTEL,EINFACH. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können."
         enum:
-          - EINFACH
-          - MITTEL
-          - UEBERWIEGEND
-          - UMFASSEND
+        - EINFACH
+        - MITTEL
+        - UEBERWIEGEND
+        - UMFASSEND
       modernisierungsArt:
         type: string
         description: "Erlaubte Werte sind: KERNSANIERUNG, DACHERNEUERUNG, FENSTER, ROHRLEITUNGEN, HEIZUNG, WAERMEDAEMMUNG, BAEDER, INNENAUSBAU, RAUMAUFTEILUNG. Der Client muss daher mit unbekannten Werten umgehen können."
         enum:
-          - BAEDER
-          - DACHERNEUERUNG
-          - FENSTER
-          - HEIZUNG
-          - INNENAUSBAU
-          - KERNSANIERUNG
-          - RAUMAUFTEILUNG
-          - ROHRLEITUNGEN
-          - WAERMEDAEMMUNG
+        - BAEDER
+        - DACHERNEUERUNG
+        - FENSTER
+        - HEIZUNG
+        - INNENAUSBAU
+        - KERNSANIERUNG
+        - RAUMAUFTEILUNG
+        - ROHRLEITUNGEN
+        - WAERMEDAEMMUNG
     title: Modernisierung
   ModernisierungsAngaben:
     type: object
@@ -2748,27 +2751,27 @@ definitions:
         type: string
         description: "Erlaubte Werte sind: ARBEITGEBERDARLEHEN,BAUSPARDARLEHEN,OEFFENTLICHES_DARLEHEN,RATENKREDIT. Neue Ausprägungen können kurzfristig hinzukommen. Der Client muss daher mit unbekannten Werten umgehen können."
       zinsBindung:
-        $ref: "#/definitions/ZinsBindung"
+        $ref: '#/definitions/ZinsBindung'
     title: NachrangigesExternesDarlehen
   PaginationLinks:
     type: object
     properties:
       next:
-        $ref: "#/definitions/Link"
+        $ref: '#/definitions/Link'
       prev:
-        $ref: "#/definitions/Link"
+        $ref: '#/definitions/Link'
       self:
-        $ref: "#/definitions/Link"
+        $ref: '#/definitions/Link'
     title: PaginationLinks
   Partner:
     type: object
     properties:
       _links:
-        $ref: "#/definitions/Links"
+        $ref: '#/definitions/Links'
       anrede:
         type: string
       anschrift:
-        $ref: "#/definitions/Anschrift"
+        $ref: '#/definitions/Anschrift'
       aufsichtsBehoerde:
         type: string
       email:
@@ -2785,7 +2788,7 @@ definitions:
         type: array
         description: Liste aller Partnerkennzeichen
         items:
-          $ref: "#/definitions/PartnerKennzeichen"
+          $ref: '#/definitions/PartnerKennzeichen'
       registrierungsNummer:
         type: string
       telefonnummer:
@@ -2819,22 +2822,22 @@ definitions:
         type: string
         description: Auszuführende Operation
         enum:
-          - add
-          - copy
-          - move
-          - remove
-          - replace
-          - test
+        - add
+        - copy
+        - move
+        - remove
+        - replace
+        - test
       path:
         type: string
         description: "JSON-Path im Antrag. Valide Pfade sind: '/antragsReferenz', '/status', '/status/antragsteller', '/ansprechpartner/partnerId', '/status/produktAnbieter', '/voraussichtlicheBearbeitung'."
       value:
         type: object
-        example: '"WER123", 1234, {"antragsteller": "BEANTRAGT"}'
+        example: "\"WER123\", 1234, {\"antragsteller\": \"BEANTRAGT\"}"
         description: "Zu setzender oder auszutauschender Wert. Erlaubt sind string, number oder JSON object"
         properties: {}
     title: PatchOperation
-    description: 'A JSONPatch document as defined by RFC 6902 (see http://jsonpatch.com/). Beispiel: { "op": "replace", "path": "/antragsReferenz", "value": "123-ABC"" }'
+    description: "A JSONPatch document as defined by RFC 6902 (see http://jsonpatch.com/). Beispiel: { \"op\": \"replace\", \"path\": \"/antragsReferenz\", \"value\": \"123-ABC\"\" }"
   Postadresse:
     type: object
     properties:
@@ -2850,54 +2853,54 @@ definitions:
   PrivatDarlehen:
     title: PrivatDarlehen
     allOf:
-      - $ref: "#/definitions/GegenangebotDarlehen"
-      - type: object
-        required:
-          - anfaenglicheTilgung
-          - darlehensBetrag
-          - darlehensTyp
-          - effektivZins
-          - laufzeitKalkulatorischInMonaten
-          - rateMonatlich
-          - sollZins
-          - vertriebsProvisionGesamtAbsolut
-          - zinsBindungInMonaten
-        discriminator: darlehensTyp
-        properties:
-          anfaenglicheTilgung:
-            type: number
-          darlehensBetrag:
-            type: number
-          darlehensTyp:
-            type: string
-            enum:
-              - ANNUITAETEN_DARLEHEN
-              - FORWARD_DARLEHEN
-              - KFW_DARLEHEN
-              - PRIVAT_DARLEHEN
-              - REGIONAL_FOERDER_DARLEHEN
-              - VARIABLES_DARLEHEN
-              - ZWISCHEN_FINANZIERUNG
-          effektivZins:
-            type: number
-          laufzeitKalkulatorischInMonaten:
-            type: integer
-            format: int32
-          produktDetails:
-            type: string
-            description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
-          rateMonatlich:
-            type: number
-          sollZins:
-            type: number
-          vertriebsProvisionGesamtAbsolut:
-            type: number
-            description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
-          zinsBindungInMonaten:
-            type: integer
-            format: int32
-        title: PrivatDarlehen
-        description: Erweitert GegenangebotDarlehen
+    - $ref: '#/definitions/GegenangebotDarlehen'
+    - type: object
+      required:
+      - anfaenglicheTilgung
+      - darlehensBetrag
+      - darlehensTyp
+      - effektivZins
+      - laufzeitKalkulatorischInMonaten
+      - rateMonatlich
+      - sollZins
+      - vertriebsProvisionGesamtAbsolut
+      - zinsBindungInMonaten
+      discriminator: darlehensTyp
+      properties:
+        anfaenglicheTilgung:
+          type: number
+        darlehensBetrag:
+          type: number
+        darlehensTyp:
+          type: string
+          enum:
+          - ANNUITAETEN_DARLEHEN
+          - FORWARD_DARLEHEN
+          - KFW_DARLEHEN
+          - PRIVAT_DARLEHEN
+          - REGIONAL_FOERDER_DARLEHEN
+          - VARIABLES_DARLEHEN
+          - ZWISCHEN_FINANZIERUNG
+        effektivZins:
+          type: number
+        laufzeitKalkulatorischInMonaten:
+          type: integer
+          format: int32
+        produktDetails:
+          type: string
+          description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
+        rateMonatlich:
+          type: number
+        sollZins:
+          type: number
+        vertriebsProvisionGesamtAbsolut:
+          type: number
+          description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
+        zinsBindungInMonaten:
+          type: integer
+          format: int32
+      title: PrivatDarlehen
+      description: Erweitert GegenangebotDarlehen
     description: Erweitert GegenangebotDarlehen
   Problem:
     type: object
@@ -2914,7 +2917,7 @@ definitions:
       violations:
         type: array
         items:
-          $ref: "#/definitions/Violation"
+          $ref: '#/definitions/Violation'
     title: Problem
   ProduktAnbieter:
     type: object
@@ -2922,7 +2925,7 @@ definitions:
       anrede:
         type: string
       anschrift:
-        $ref: "#/definitions/Anschrift"
+        $ref: '#/definitions/Anschrift'
       aufsichtsBehoerde:
         type: string
       email:
@@ -2939,7 +2942,7 @@ definitions:
         type: array
         description: Liste aller Partnerkennzeichen
         items:
-          $ref: "#/definitions/PartnerKennzeichen"
+          $ref: '#/definitions/PartnerKennzeichen'
       produktAnbieterId:
         type: string
       produktAnbieterKurzName:
@@ -2981,75 +2984,75 @@ definitions:
   RegionalFoerderDarlehen:
     title: RegionalFoerderDarlehen
     allOf:
-      - $ref: "#/definitions/GegenangebotDarlehen"
-      - type: object
-        required:
-          - anfaenglicheTilgung
-          - bereitstellungsZins
-          - bereitstellungsZinsFreieZeitInMonaten
-          - darlehensBetrag
-          - darlehensTyp
-          - effektivZins
-          - laufzeitKalkulatorischInJahren
-          - rateMonatlich
-          - rateMonatlichInDerTilgungsfreienAnlaufzeit
-          - regionalFoerderbankProgramm
-          - sollZins
-          - tilgungsFreieAnlaufJahre
-          - vertriebsProvisionGesamtAbsolut
-          - zinsBindungInJahren
-        discriminator: darlehensTyp
-        properties:
-          anfaenglicheTilgung:
-            type: number
-          bereitstellungsZins:
-            type: number
-          bereitstellungsZinsFreieZeitInMonaten:
-            type: integer
-            format: int32
-          darlehensBetrag:
-            type: number
-          darlehensTyp:
-            type: string
-            enum:
-              - ANNUITAETEN_DARLEHEN
-              - FORWARD_DARLEHEN
-              - KFW_DARLEHEN
-              - PRIVAT_DARLEHEN
-              - REGIONAL_FOERDER_DARLEHEN
-              - VARIABLES_DARLEHEN
-              - ZWISCHEN_FINANZIERUNG
-          effektivZins:
-            type: number
-          laufzeitKalkulatorischInJahren:
-            type: integer
-            format: int32
-          produktDetails:
-            type: string
-            description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
-          rateMonatlich:
-            type: number
-          rateMonatlichInDerTilgungsfreienAnlaufzeit:
-            type: number
-          regionalFoerderbankProgramm:
-            type: string
-            enum:
-              - L_BANK_KOMBI_DARLEHEN_WOHNEN
-              - L_BANK_WOHNEN_MIT_KIND
-              - NRW_BANK_WOHNEIGENTUM
-          sollZins:
-            type: number
-          tilgungsFreieAnlaufJahre:
-            type: integer
-            format: int32
-          vertriebsProvisionGesamtAbsolut:
-            type: number
-            description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
-          zinsBindungInJahren:
-            type: integer
-            format: int32
-        title: RegionalFoerderDarlehen
-        description: Erweitert GegenangebotDarlehen
+    - $ref: '#/definitions/GegenangebotDarlehen'
+    - type: object
+      required:
+      - anfaenglicheTilgung
+      - bereitstellungsZins
+      - bereitstellungsZinsFreieZeitInMonaten
+      - darlehensBetrag
+      - darlehensTyp
+      - effektivZins
+      - laufzeitKalkulatorischInJahren
+      - rateMonatlich
+      - rateMonatlichInDerTilgungsfreienAnlaufzeit
+      - regionalFoerderbankProgramm
+      - sollZins
+      - tilgungsFreieAnlaufJahre
+      - vertriebsProvisionGesamtAbsolut
+      - zinsBindungInJahren
+      discriminator: darlehensTyp
+      properties:
+        anfaenglicheTilgung:
+          type: number
+        bereitstellungsZins:
+          type: number
+        bereitstellungsZinsFreieZeitInMonaten:
+          type: integer
+          format: int32
+        darlehensBetrag:
+          type: number
+        darlehensTyp:
+          type: string
+          enum:
+          - ANNUITAETEN_DARLEHEN
+          - FORWARD_DARLEHEN
+          - KFW_DARLEHEN
+          - PRIVAT_DARLEHEN
+          - REGIONAL_FOERDER_DARLEHEN
+          - VARIABLES_DARLEHEN
+          - ZWISCHEN_FINANZIERUNG
+        effektivZins:
+          type: number
+        laufzeitKalkulatorischInJahren:
+          type: integer
+          format: int32
+        produktDetails:
+          type: string
+          description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
+        rateMonatlich:
+          type: number
+        rateMonatlichInDerTilgungsfreienAnlaufzeit:
+          type: number
+        regionalFoerderbankProgramm:
+          type: string
+          enum:
+          - L_BANK_KOMBI_DARLEHEN_WOHNEN
+          - L_BANK_WOHNEN_MIT_KIND
+          - NRW_BANK_WOHNEIGENTUM
+        sollZins:
+          type: number
+        tilgungsFreieAnlaufJahre:
+          type: integer
+          format: int32
+        vertriebsProvisionGesamtAbsolut:
+          type: number
+          description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
+        zinsBindungInJahren:
+          type: integer
+          format: int32
+      title: RegionalFoerderDarlehen
+      description: Erweitert GegenangebotDarlehen
     description: Erweitert GegenangebotDarlehen
   RisikoAbsicherung:
     type: object
@@ -3057,23 +3060,23 @@ definitions:
       abgesichertesRisiko:
         type: string
         enum:
-          - ARBEITSLOSIGKEIT
-          - ARBEITSUNFAEHIGKEIT
-          - ASSISTANCE_ARBEITSLOSIGKEIT
-          - ASSISTANCE_ARBEITSUNFAEHIGKEIT
-          - INVALIDITAET
-          - SCHWERE_KRANKHEIT
-          - TODESFALL
+        - ARBEITSLOSIGKEIT
+        - ARBEITSUNFAEHIGKEIT
+        - ASSISTANCE_ARBEITSLOSIGKEIT
+        - ASSISTANCE_ARBEITSUNFAEHIGKEIT
+        - INVALIDITAET
+        - SCHWERE_KRANKHEIT
+        - TODESFALL
       auszahlungsBetrag:
         type: number
       auszahlungsTurnus:
         type: string
         enum:
-          - EINMALIG
-          - HALBJAEHRLICH
-          - JAEHRLICH
-          - MONATLICH
-          - VIERTELJAEHRLICH
+        - EINMALIG
+        - HALBJAEHRLICH
+        - JAEHRLICH
+        - MONATLICH
+        - VIERTELJAEHRLICH
       praemienAnteil:
         type: number
     title: RisikoAbsicherung
@@ -3116,11 +3119,11 @@ definitions:
       zahlweise:
         type: string
         enum:
-          - EINMALIG
-          - HALBJAEHRLICH
-          - JAEHRLICH
-          - MONATLICH
-          - VIERTELJAEHRLICH
+        - EINMALIG
+        - HALBJAEHRLICH
+        - JAEHRLICH
+        - MONATLICH
+        - VIERTELJAEHRLICH
     title: SonderZahlung
   SparPhase:
     type: object
@@ -3146,14 +3149,14 @@ definitions:
         type: string
         description: Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium
         enum:
-          - VERBINDLICHKEIT
-          - VERMOEGEN
+        - VERBINDLICHKEIT
+        - VERMOEGEN
       zahlungsTyp:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-          - AUSGABE
-          - EINNAHME
+        - AUSGABE
+        - EINNAHME
     title: Sparplaene
   Staat:
     type: object
@@ -3166,35 +3169,35 @@ definitions:
   StatusDTO:
     type: object
     required:
-      - antragsteller
-      - produktAnbieter
+    - antragsteller
+    - produktAnbieter
     properties:
       ablehnungsgrund:
         type: string
         enum:
-          - FINANZIELLE_SITUATION
-          - GEGENANGEBOT
-          - KEINE_ANGABE
-          - KRITERIEN
-          - NEGATIV_MERKMAL
-          - UNTERLAGEN_UNVOLLSTAENDIG
-          - WERTERMITTLUNG
+        - FINANZIELLE_SITUATION
+        - GEGENANGEBOT
+        - KEINE_ANGABE
+        - KRITERIEN
+        - NEGATIV_MERKMAL
+        - UNTERLAGEN_UNVOLLSTAENDIG
+        - WERTERMITTLUNG
       antragsteller:
         type: string
         enum:
-          - BEANTRAGT
-          - NICHT_ANGENOMMEN
-          - UNTERSCHRIEBEN
-          - WIDERRUFEN
+        - BEANTRAGT
+        - NICHT_ANGENOMMEN
+        - UNTERSCHRIEBEN
+        - WIDERRUFEN
       kommentar:
         type: string
       produktAnbieter:
         type: string
         enum:
-          - ABGELEHNT
-          - NICHT_BEARBEITET
-          - UNTERSCHRIEBEN
-          - ZURUECKGESTELLT
+        - ABGELEHNT
+        - NICHT_BEARBEITET
+        - UNTERSCHRIEBEN
+        - ZURUECKGESTELLT
     title: StatusDTO
   Tilgung:
     type: object
@@ -3211,7 +3214,7 @@ definitions:
         description: nullable
       tilgungsErsatz:
         description: nicht bei PRIVAT_DARLEHEN
-        $ref: "#/definitions/TilgungsErsatz"
+        $ref: '#/definitions/TilgungsErsatz'
       volltilgerDarlehen:
         type: boolean
         example: true
@@ -3243,59 +3246,59 @@ definitions:
   VariablesDarlehen:
     title: VariablesDarlehen
     allOf:
-      - $ref: "#/definitions/GegenangebotDarlehen"
-      - type: object
-        required:
-          - anfaenglicheTilgung
-          - darlehensBetrag
-          - darlehensTyp
-          - effektivZins
-          - laufzeitKalkulatorischInJahren
-          - rateMonatlich
-          - sollZins
-          - vertriebsProvisionGesamtAbsolut
-        discriminator: darlehensTyp
-        properties:
-          anfaenglicheTilgung:
-            type: number
-          bereitstellungsZins:
-            type: number
-          bereitstellungsZinsFreieZeitInMonaten:
-            type: integer
-            format: int32
-          darlehensBetrag:
-            type: number
-          darlehensTyp:
-            type: string
-            enum:
-              - ANNUITAETEN_DARLEHEN
-              - FORWARD_DARLEHEN
-              - KFW_DARLEHEN
-              - PRIVAT_DARLEHEN
-              - REGIONAL_FOERDER_DARLEHEN
-              - VARIABLES_DARLEHEN
-              - ZWISCHEN_FINANZIERUNG
-          effektivZins:
-            type: number
-          laufzeitKalkulatorischInJahren:
-            type: integer
-            format: int32
-          produktDetails:
-            type: string
-            description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
-          rateMonatlich:
-            type: number
-          sollZins:
-            type: number
-          tilgungsBeginnAm:
-            type: string
-            format: date-time
-            example: 2020-03-28
-          vertriebsProvisionGesamtAbsolut:
-            type: number
-            description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
-        title: VariablesDarlehen
-        description: Erweitert GegenangebotDarlehen
+    - $ref: '#/definitions/GegenangebotDarlehen'
+    - type: object
+      required:
+      - anfaenglicheTilgung
+      - darlehensBetrag
+      - darlehensTyp
+      - effektivZins
+      - laufzeitKalkulatorischInJahren
+      - rateMonatlich
+      - sollZins
+      - vertriebsProvisionGesamtAbsolut
+      discriminator: darlehensTyp
+      properties:
+        anfaenglicheTilgung:
+          type: number
+        bereitstellungsZins:
+          type: number
+        bereitstellungsZinsFreieZeitInMonaten:
+          type: integer
+          format: int32
+        darlehensBetrag:
+          type: number
+        darlehensTyp:
+          type: string
+          enum:
+          - ANNUITAETEN_DARLEHEN
+          - FORWARD_DARLEHEN
+          - KFW_DARLEHEN
+          - PRIVAT_DARLEHEN
+          - REGIONAL_FOERDER_DARLEHEN
+          - VARIABLES_DARLEHEN
+          - ZWISCHEN_FINANZIERUNG
+        effektivZins:
+          type: number
+        laufzeitKalkulatorischInJahren:
+          type: integer
+          format: int32
+        produktDetails:
+          type: string
+          description: Wird dem Vertrieb als Beschreibung zum Produkt angezeigt.
+        rateMonatlich:
+          type: number
+        sollZins:
+          type: number
+        tilgungsBeginnAm:
+          type: string
+          format: date-time
+          example: 2020-03-28
+        vertriebsProvisionGesamtAbsolut:
+          type: number
+          description: Enthält die Vertriebsprovision inkl. Overhead. Die Europace-Provision wird separat berechnet.
+      title: VariablesDarlehen
+      description: Erweitert GegenangebotDarlehen
     description: Erweitert GegenangebotDarlehen
   Verbindlichkeit:
     type: object
@@ -3313,16 +3316,16 @@ definitions:
         type: string
         description: Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium
         enum:
-          - VERBINDLICHKEIT
-          - VERMOEGEN
+        - VERBINDLICHKEIT
+        - VERMOEGEN
       wirdAbgeloest:
         type: boolean
       zahlungsTyp:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-          - AUSGABE
-          - EINNAHME
+        - AUSGABE
+        - EINNAHME
     title: Verbindlichkeit
   VermietungsInformationen:
     type: object
@@ -3332,9 +3335,9 @@ definitions:
       nutzungsArt:
         type: string
         enum:
-          - EIGENGENUTZT
-          - TEIL_VERMIETET
-          - VERMIETET
+        - EIGENGENUTZT
+        - TEIL_VERMIETET
+        - VERMIETET
       vermieteteFlaeche:
         type: number
     title: VermietungsInformationen
@@ -3349,8 +3352,8 @@ definitions:
         type: string
         description: Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium
         enum:
-          - VERBINDLICHKEIT
-          - VERMOEGEN
+        - VERBINDLICHKEIT
+        - VERMOEGEN
     title: Vermoegen
   VermoegenVerbindlichkeit:
     type: object
@@ -3366,8 +3369,8 @@ definitions:
       vermoegensTyp:
         type: string
         enum:
-          - VERBINDLICHKEIT
-          - VERMOEGEN
+        - VERBINDLICHKEIT
+        - VERMOEGEN
     title: VermoegenVerbindlichkeit
   VermoegenVerbindlichkeiten:
     type: object
@@ -3375,7 +3378,7 @@ definitions:
       vermoegenOderVerbindlichkeiten:
         type: array
         items:
-          $ref: "#/definitions/VermoegenVerbindlichkeit"
+          $ref: '#/definitions/VermoegenVerbindlichkeit'
     title: VermoegenVerbindlichkeiten
   VersicherungsZeitraum:
     type: object
@@ -3406,24 +3409,24 @@ definitions:
       externeBausparAngebote:
         type: array
         items:
-          $ref: "#/definitions/BausparAngebot"
+          $ref: '#/definitions/BausparAngebot'
       finanzbedarf:
-        $ref: "#/definitions/Finanzbedarf"
+        $ref: '#/definitions/Finanzbedarf'
       nachfinanzierung:
         type: boolean
       nachrangigeExterneDarlehen:
         type: array
         items:
-          $ref: "#/definitions/NachrangigesExternesDarlehen"
+          $ref: '#/definitions/NachrangigesExternesDarlehen'
       verwendungszweck:
         type: string
         enum:
-          - ANSCHLUSSFINANZIERUNG
-          - KAPITALBESCHAFFUNG
-          - KAUF
-          - KAUF_NEUBAU_VOM_BAUTRAEGER
-          - MODERNISIERUNG_UMBAU_ANBAU
-          - NEUBAU
+        - ANSCHLUSSFINANZIERUNG
+        - KAPITALBESCHAFFUNG
+        - KAUF
+        - KAUF_NEUBAU_VOM_BAUTRAEGER
+        - MODERNISIERUNG_UMBAU_ANBAU
+        - NEUBAU
     title: Vorhaben
   Wertpapiere:
     type: object
@@ -3438,24 +3441,24 @@ definitions:
         type: string
         description: Redundante Angabe des Vermögenstyp dient als zusätzliches Filterkriterium
         enum:
-          - VERBINDLICHKEIT
-          - VERMOEGEN
+        - VERBINDLICHKEIT
+        - VERMOEGEN
       zahlungsTyp:
         type: string
         description: Redundante Angabe des Zahlungstyps dient als zusätzliches Filterkriterium
         enum:
-          - AUSGABE
-          - EINNAHME
+        - AUSGABE
+        - EINNAHME
     title: Wertpapiere
   Zahlungsplaene:
     type: object
     properties:
       _links:
-        $ref: "#/definitions/Links"
+        $ref: '#/definitions/Links'
       zahlungsplaene:
         type: array
         items:
-          $ref: "#/definitions/zahlungsplan"
+          $ref: '#/definitions/zahlungsplan'
     title: Zahlungsplaene
   ZinsBindung:
     type: object
@@ -3476,17 +3479,17 @@ definitions:
     type: object
     properties:
       _links:
-        $ref: "#/definitions/Links"
+        $ref: '#/definitions/Links'
       bankverbindung:
-        $ref: "#/definitions/Bankverbindung"
+        $ref: '#/definitions/Bankverbindung'
       finanzierungsObjekt:
-        $ref: "#/definitions/FinanzierungsObjekt"
+        $ref: '#/definitions/FinanzierungsObjekt'
       haushalte:
         type: array
         items:
-          $ref: "#/definitions/Haushalt"
+          $ref: '#/definitions/Haushalt'
       vorhaben:
-        $ref: "#/definitions/Vorhaben"
+        $ref: '#/definitions/Vorhaben'
     title: ZugrundeliegendeDatenZumAntrag
   zahlungsplan:
     type: object
@@ -3496,16 +3499,16 @@ definitions:
       eintraege:
         type: array
         items:
-          $ref: "#/definitions/Eintrag"
+          $ref: '#/definitions/Eintrag'
       gesamtSumme:
-        $ref: "#/definitions/Eintrag"
+        $ref: '#/definitions/Eintrag'
       sparplanSummenEintragZumZuteilungsZeitpunkt:
-        $ref: "#/definitions/Eintrag"
+        $ref: '#/definitions/Eintrag'
       summeEndeDerZinsbindung:
-        $ref: "#/definitions/Eintrag"
+        $ref: '#/definitions/Eintrag'
       typ:
         type: string
         enum:
-          - TILGUNGSPLAN
+        - TILGUNGSPLAN
     title: zahlungsplan
     description: Diese Resource repräsentiert einen Zahlungsplan.


### PR DESCRIPTION
closes [MTV-570]

### Motivation
Wenn eien PA mehrere Anträge an einem Vorgang besistzt, dann zeigen wir ihm an, welcher gerade im aktiven Status ist. Es könne auch alle Anträge inaktiv sein.

Hintergrund ist das Deuba-Projekt, das aktuell nicht auf den aktiven Antrag zugreifen kann.
### Änderungen
> Zusammenfassung der fachlichen Änderungen
> 
> Bei Frontendanpassungen Screenshots hinzufügen, aus denen die Änderung ersichtlich wird.

### Test
> Wie können die Änderungen getestet werden?
>
> Auf welcher Ebene sind die Tests (siehe Testpyramide)




[MTV-570]: https://europace.atlassian.net/browse/MTV-570